### PR TITLE
update.bat: resolve the real Desktop for the icon tip (OneDrive redirect)

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -55,7 +55,12 @@ for %%r in (fullstack-agent ai-memory-vault backtalk barehands ai-visualizer) do
   if exist "%%r\.git\" call :one "%%r"
 )
 echo update complete.
-if not exist "%USERPROFILE%\Desktop\Update *" echo Tip: want a desktop Update icon that does this on a double-click? Open your agent and ask for one.
+rem Resolve the real Desktop folder (OneDrive redirection moves it off
+rem %USERPROFILE%\Desktop); fall back to the classic path if the query fails.
+set "DESKTOP_DIR="
+for /f "delims=" %%d in ('powershell -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2^>nul') do set "DESKTOP_DIR=%%d"
+if not defined DESKTOP_DIR set "DESKTOP_DIR=%USERPROFILE%\Desktop"
+if not exist "%DESKTOP_DIR%\Update *" echo Tip: want a desktop Update icon that does this on a double-click? Open your agent and ask for one.
 exit /b 0
 
 :one


### PR DESCRIPTION
## The problem

On Windows machines where OneDrive redirects the Desktop (very common on Windows 11 — the Desktop lives at `%USERPROFILE%\OneDrive\Desktop`), the end-of-update tip

> Tip: want a desktop Update icon that does this on a double-click? Open your agent and ask for one.

fires even when the user is running the update **from that very icon**, because the check hardcodes `%USERPROFILE%\Desktop`.

## The fix

Resolve the actual Desktop folder with `[Environment]::GetFolderPath('Desktop')` (which follows the OneDrive/Known Folder redirection), and fall back to the classic `%USERPROFILE%\Desktop` if the PowerShell query fails for any reason. No behavior change on non-redirected machines.

Tested on Windows 11 with a OneDrive-redirected Desktop and an `Update <name>.bat` icon present: full update run of all five repos, tip correctly suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
