### PR TITLE
Add fullstack-kimi installer scaffold

### DIFF
--- a/fullstack-kimi/.gitignore
+++ b/fullstack-kimi/.gitignore
@@ -1,0 +1,4 @@
+# User-specific state and configs live outside git tracking
+*.mine
+*.log
+.DS_Store

--- a/fullstack-kimi/.gitignore
+++ b/fullstack-kimi/.gitignore
@@ -2,3 +2,4 @@
 *.mine
 *.log
 .DS_Store
+.venv/

--- a/fullstack-kimi/KIMI.md
+++ b/fullstack-kimi/KIMI.md
@@ -1,0 +1,16 @@
+# fullstack-kimi: the installer
+
+You are reading the boot file of the **fullstack-kimi** installer repo. You are not the user's agent yet; you are the assistant that builds one. Your job in this folder is exactly one thing: walk the person through setup, warmly and in plain English.
+
+**On the first message of a session here, check the state of things and respond accordingly:**
+
+1. **Setup not done yet** (the parent folder of this repo has no `AGENTS.md` or `KIMI.md`, or the person asks to get set up): most people arrive with "set me up" as their first message. The moment you see it (or anything like it), **read `fullstack-kimi.md` in this folder and follow it exactly**; that file is the whole setup wizard. If their first message is something else, introduce yourself in one short line ("I'm the fullstack-kimi installer. Say **set me up** and I'll build your Kimi agent with you.") and wait.
+
+2. **Setup already done** (the parent folder has an `AGENTS.md` or `KIMI.md` and at least one of the tool folders beside this one): say so, and offer the useful things instead: start the agent (`./fullstack-kimi/start.sh` from the parent folder), update everything (`./fullstack-kimi/update.sh`), re-run part of the setup, or add a piece they skipped. Remind them gently: for everyday work they should open Kimi Code CLI in the **PARENT** folder, where their agent lives; this folder is just the toolbox.
+
+**Rules that bind you in this folder:**
+
+- Talk like a person, not a manual. The person may have installed Kimi Code yesterday. No jargon without a one-line explanation.
+- Never delete, overwrite, or move anything the person built. The wizard's adoption rules in `fullstack-kimi.md` are binding.
+- Ask one question at a time and wait for the answer.
+- Do the work yourself (run the commands, edit the configs) instead of telling the person to do it, unless a step genuinely requires their hands.

--- a/fullstack-kimi/README.md
+++ b/fullstack-kimi/README.md
@@ -1,6 +1,6 @@
 # fullstack-kimi
 
-> **Status:** installer scaffold + working visualizer. `kimi-visualizer` is bundled and runs a browser-based face. The other component repos (`kimi-memory-vault`, `kimi-voice`, `kimi-barehands`) are stubs that will be linked once they are published.
+> **Status:** installer scaffold + working voice and visualizer. `kimi-voice` and `kimi-visualizer` are bundled and run together. The other component repos (`kimi-memory-vault`, `kimi-barehands`) are stubs that will be linked once they are published.
 
 A Kimi-powered port of [fullstack-agent](https://github.com/jaredrhod/fullstack-agent). It gives Kimi Code CLI the same full stack: **memory, voice, face, and optional hands**.
 

--- a/fullstack-kimi/README.md
+++ b/fullstack-kimi/README.md
@@ -1,6 +1,6 @@
 # fullstack-kimi
 
-> **Status:** installer scaffold. The component repos (`kimi-memory-vault`, `kimi-voice`, `kimi-visualizer`, `kimi-barehands`) are stubs that will be linked once they are published. This directory contains the installer, launcher, and wiring logic.
+> **Status:** installer scaffold + working visualizer. `kimi-visualizer` is bundled and runs a browser-based face. The other component repos (`kimi-memory-vault`, `kimi-voice`, `kimi-barehands`) are stubs that will be linked once they are published.
 
 A Kimi-powered port of [fullstack-agent](https://github.com/jaredrhod/fullstack-agent). It gives Kimi Code CLI the same full stack: **memory, voice, face, and optional hands**.
 

--- a/fullstack-kimi/README.md
+++ b/fullstack-kimi/README.md
@@ -1,0 +1,55 @@
+# fullstack-kimi
+
+> **Status:** installer scaffold. The component repos (`kimi-memory-vault`, `kimi-voice`, `kimi-visualizer`, `kimi-barehands`) are stubs that will be linked once they are published. This directory contains the installer, launcher, and wiring logic.
+
+A Kimi-powered port of [fullstack-agent](https://github.com/jaredrhod/fullstack-agent). It gives Kimi Code CLI the same full stack: **memory, voice, face, and optional hands**.
+
+## Why Kimi Code CLI as the brain?
+
+Kimi Code CLI is the terminal agent from Moonshot AI. It reads files, runs shell commands, calls tools, and supports MCP servers. By building around it instead of calling the raw Kimi API, we reuse:
+
+- Session history and resume (`kimi --continue`)
+- Tool use and MCP
+- Project context via `AGENTS.md`
+- The Wire protocol, which lets external programs drive a session
+
+The other pieces connect to Kimi Code CLI through **state files** and the **Wire bridge**.
+
+## What you get
+
+- **The mind: `kimi-memory-vault`.** Persistent memory built on plain text markdown files that Kimi Code reads and writes.
+- **The mouth: `kimi-voice`.** Push-to-talk voice input and spoken output. Bridges to Kimi Code CLI over Wire.
+- **The face: `kimi-visualizer`.** Browser-based visualizers that idle, listen, think, and speak in sync.
+- **The hands: `kimi-barehands` (optional).** Webcam hand-tracking for moving notes and images.
+
+## Install
+
+Requires [Kimi Code CLI](https://www.kimi.com/code) and git. Then one paste into your terminal:
+
+```bash
+mkdir -p ~/my-kimi-agent && cd ~/my-kimi-agent && git clone https://github.com/jaredrhod/fullstack-kimi && cd fullstack-kimi && kimi "set me up"
+```
+
+The installer asks which pieces you want, sets up the vault, wires the configs, and leaves Desktop shortcuts.
+
+## After setup
+
+- **Chat:** double-click `Chat with <name>` to open a typed Kimi Code CLI session.
+- **Talk:** double-click `Talk with <name>` for voice + face.
+- **Hands:** double-click `<name> barehands` for voice + hand board.
+- **Update:** double-click `Update <name>` to pull the newest versions.
+
+## Differences from fullstack-agent
+
+| fullstack-agent | fullstack-kimi |
+|-----------------|----------------|
+| Claude Code host | Kimi Code CLI host |
+| `CLAUDE.md` identity | `AGENTS.md` + optional `SYSTEM.md` identity |
+| `claude --continue` | `kimi --continue` |
+| `backtalk` voice bridge | `kimi-voice` Wire bridge |
+
+## License
+
+Copyright (c) 2026 Jared Rhodenizer.
+
+Licensed under the GNU Affero General Public License, version 3 or later (AGPL-3.0-or-later). See the root `LICENSE` file for full terms.

--- a/fullstack-kimi/README.md
+++ b/fullstack-kimi/README.md
@@ -1,6 +1,6 @@
 # fullstack-kimi
 
-> **Status:** installer scaffold + working voice and visualizer. `kimi-voice` and `kimi-visualizer` are bundled and run together. The other component repos (`kimi-memory-vault`, `kimi-barehands`) are stubs that will be linked once they are published.
+> **Status:** complete first-pass stack. `kimi-voice`, `kimi-visualizer`, `kimi-memory-vault`, and `kimi-barehands` are all bundled and wired together. The installer and update scripts know how to find them either as siblings or inside this repo.
 
 A Kimi-powered port of [fullstack-agent](https://github.com/jaredrhod/fullstack-agent). It gives Kimi Code CLI the same full stack: **memory, voice, face, and optional hands**.
 

--- a/fullstack-kimi/TROUBLESHOOTING.md
+++ b/fullstack-kimi/TROUBLESHOOTING.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+This file covers only the problems that live BETWEEN the pieces. Each piece owns its own deeper guide: `kimi-memory-vault/TROUBLESHOOTING.md`, `kimi-voice/TROUBLESHOOTING.md`, `kimi-barehands/TROUBLESHOOTING.md`, `kimi-visualizer/TROUBLESHOOTING.md`.
+
+## I closed the window in the middle of setup
+
+Nothing is lost. Open a new terminal, go back to the toolbox folder (`cd ~/my-kimi-agent/fullstack-kimi`), and run:
+
+```
+kimi --continue
+```
+
+That reopens your most recent session. Tell it "we got cut off, keep going with the setup."
+
+## The install command opened Kimi Code CLI, but it acts like nothing's there
+
+Then the download step failed before Kimi Code CLI started, and the error is in your terminal scrollback. Type `/exit`, scroll up, and read it.
+
+## Kimi Code CLI says "command not found"
+
+Install Kimi Code CLI first: <https://www.kimi.com/code>. The installer expects the `kimi` command on your PATH.
+
+## The face sits at idle while the voice talks
+
+The wiring is one config line, plus a restart. Check both:
+
+1. `kimi-visualizer/kimi-visualizer.json` should have `"bus_dir"` pointing at your `kimi-voice` folder.
+2. Restart the visualizer server after any config change (Ctrl-C the stack, run start.sh again).
+
+## The greeting doesn't speak on launch
+
+The greeting line lives in `kimi-voice/kimi-voice.json` under `"greeting"`. If it is missing or empty, the launch is silent by configuration.
+
+## start.sh says a piece is starting but nothing appears
+
+- The face opens a browser tab automatically. If no tab appears, open `http://127.0.0.1:8790/` yourself and pick your face from the gallery.
+- The hands never open a tab automatically: open `http://127.0.0.1:8794/` in Chrome.
+- Two stacks can't run at once. If a port is already busy from an earlier session, Ctrl-C the old terminal or close it, then start again.
+
+## My agent forgot who it is
+
+Your agent's identity lives in the `AGENTS.md` (and optional `SYSTEM.md`) in your HOME folder (the folder containing all the tool folders), and Kimi Code CLI only reads it when you open Kimi Code CLI IN that folder. Opening Kimi Code CLI inside one of the tool subfolders boots the tool's own instructions instead.
+
+## I moved my agent folder somewhere else
+
+Everything is wired with paths, so a move breaks the wires. Open Kimi Code CLI in the new location and say: "read fullstack-kimi/fullstack-kimi.md and re-run the wiring phase."
+
+## Updates
+
+`./fullstack-kimi/update.sh` pulls every piece. Your files (your AGENTS.md/KIMI.md, your vault, your notes) are never inside the repos' tracked files, so updates cannot touch them.

--- a/fullstack-kimi/fullstack-kimi.md
+++ b/fullstack-kimi/fullstack-kimi.md
@@ -1,0 +1,136 @@
+# fullstack-kimi: setup
+
+You are the user's Kimi Code CLI agent, and you are about to assemble a complete one: memory, voice, face, and hands. This file is the conductor. It collects every answer ONCE, then runs each piece's own setup with those answers already in hand, then wires everything together, and it ends with the agent's first spoken words.
+
+This is a Kimi-powered port of [fullstack-agent](https://github.com/jaredrhod/fullstack-agent). The brain is **Kimi Code CLI** — the terminal agent that reads files, runs commands, and calls tools. The other pieces (memory, voice, face, hands) are local services that connect to it.
+
+Ground rules, binding for the whole run:
+
+- **Plain English.** Assume the person installed Kimi Code yesterday. Every technical thing gets a one-line explanation before it gets a name.
+- **One question at a time.** Wait for each answer.
+- **Never delete, overwrite, or move anything the person built.** Replacing something means the new piece takes over and the old one stays on disk, untouched, and you say so out loud.
+- **You do the work.** Run the commands, write the configs, make the edits. The person only acts when a step truly needs their hands (granting camera or mic permission, typing a password).
+
+## Phase 0: Find home, and find what already exists
+
+**Prerequisite check, before anything else: git.** Check with `git --version`. If it's missing, ask first, never silently: "One tool before we build: git, the free program that downloads and updates all the pieces. Want me to install it for you right now?" On a clear yes, install it (the platform-appropriate way) and verify it landed.
+
+**Then, if this repo has no `.git` folder inside it** (it arrived as a zip): convert it into a real clone in place, so the update script can reach it forever after. Inside this folder: `git init -b main`, `git remote add origin https://github.com/jaredrhod/fullstack-kimi`, `git fetch origin`, `git reset --hard origin/main`, `git branch --set-upstream-to=origin/main main`. Nothing the person sees changes; the folder just gains its connection to updates. Do this quietly and move on.
+
+The agent's home is the folder **CONTAINING** this repo. Confirm that with the person in plain terms: "everything about your agent will live in [path], and this toolbox folder sits inside it." If they cloned this repo somewhere accidental (their Downloads folder, say), ask where the agent should live, create that folder, and move this repo inside it before going on.
+
+Then look around the home folder and establish which situation you are in:
+
+- **An `AGENTS.md` or `KIMI.md` already exists in the home** (or they tell you they already have an agent set up elsewhere): read it. If it defines an agent with a name and personality, you are **ADOPTING**, not creating. Say something like "found [name], keeping them exactly as they are," and skip every identity question later.
+- **Nothing there:** fresh start. All questions apply.
+
+**If their agent lives somewhere else, THAT folder is the home.** Move this toolbox repo inside it, remove the now-empty folder the install command created, and proceed as an adoption. Never make a second home for an agent that already has one.
+
+Three scanning rules that hold for the whole run:
+
+1. **Old Kimi Code project memory is fair game.** If there are past sessions or project notes the person wants the new memory system to take over, list them and ask which ones to migrate. Migration copies; it never deletes the originals.
+2. **Existing Obsidian vaults are off-limits in the new-vault path.** If the person chose "use my existing vault," you work with the one vault they pointed at. If they chose a new vault, you never read any other vault they own.
+3. **Everywhere else on their disk: ask before you look.** The home folder and the specific paths they point you at are yours to work in; any scan beyond that requires permission first, every time.
+
+## Phase 1: The menu
+
+Offer the stack, each piece in one plain sentence. **Lead with the easy answer: "the stack" (all three) is the first option and the default.**
+
+1. **The memory**: a filing cabinet of plain text files your AI actually reads and writes, so it remembers you, your work, and every lesson across every session.
+2. **The voice**: hold a key, say the thing out loud, and your agent answers through your speakers about a second later.
+3. **The face**: a living visualizer in your browser that idles, listens, thinks, and speaks in sync with your agent.
+
+Then mention the optional add-on, once, without pushing it:
+
+- **The hands** *(optional extra, needs a webcam)*: move notes and images around your screen with your bare hands, no controllers, no headset.
+
+## Phase 2: The one interview
+
+Collect every remaining answer now, so no later step ever has to ask. Skip anything Phase 0 already adopted or Phase 1 declined.
+
+1. **Their name.** You will use it in the finale.
+2. **The agent's identity** (skip entirely if adopted): offer three doors — A: take a default persona as-is, B: rename it, C: build from scratch. If they shrug, door A.
+3. **The vault** (memory piece): Obsidian is required — it is how the person sees and owns their agent's memory. Check `obsidian.json` for existing vaults, offer them by name, and always offer a brand-new vault just for this system. A fresh vault lives at `~/<their name for it>`, directly in the home folder next to the agent folder.
+4. **The microphone** (voice piece): push-to-talk (default, mic closed unless a key is held) or hands-free listening (always on). Then, which key. Defaults: push-to-talk, the home key.
+5. **The voice engine** (voice piece): built-in/local (free, offline, decent but synthetic) or cloud TTS (natural, needs an account/key). Capture which they want.
+6. **The default face** (face piece): board, radial, rain, or neural. Default: board.
+7. **Permissions** (voice piece): when their agent wants to do something real mid-conversation, should it ask out loud first and wait for spoken yes/no (default), or run fully auto-approved? Their answer lands in the voice config in Phase 4.
+
+## Phase 3: Install the pieces
+
+Clone each chosen piece into the home folder as a sibling of this repo, from `github.com/jaredrhod/<name>`:
+`kimi-memory-vault`, `kimi-voice`, `kimi-visualizer`, `kimi-barehands`.
+
+**The adoption exceptions, checked before each clone:**
+
+- A piece already downloaded from these repos somewhere on the machine, that they actively use: do not duplicate it. Wire to their copy where it stands.
+- A stale, unmodified copy sitting outside the home folder is different: prefer a fresh copy inside the home (so the update script reaches it) and leave the old one untouched.
+
+**If the memory piece was declined, write the agent's brain yourself, before anything else installs.** Create a short `AGENTS.md` in the HOME folder carrying the identity from Phase 2: the agent's name, role, personality, and welcome line, plus one line saying this folder is where the agent lives.
+
+**Then run each piece's own setup, in this order, with the Phase 2 answers pre-supplied.** Each repo has a wizard file (`kimi-memory-vault.md`, `kimi-voice.md`, `kimi-barehands.md`, `kimi-visualizer.md`). Read each one and execute it faithfully, with one standing modification: any question the interview already answered gets filled in silently instead of asked again.
+
+1. **kimi-memory-vault** first (it creates the vault and writes the person's `AGENTS.md` / `KIMI.md` into the HOME folder).
+2. **kimi-voice** second (it installs Python deps, STT/TTS models, and the push-to-talk listener).
+3. **kimi-visualizer** third (no heavy dependencies; seconds).
+4. **kimi-barehands** fourth (no dependencies; camera permission happens on first open).
+
+## Phase 4: Wire the seams
+
+This part belongs to this wizard alone. Write these config values, then read each file back to confirm it landed:
+
+- `kimi-voice/kimi-voice.json`: `agent_dir` = the home folder. `name` = the agent's name. Add the vault's path to `extra_dirs`. If hands were installed: `barehands_state_dir` = the `kimi-barehands/state` folder.
+- `kimi-voice/kimi-voice.json` greeting: set it to exactly `Hello <their name>, what are we working on today?`
+- `kimi-voice/kimi-voice.json`: `permission_mode` = their Phase 2 answer, `"ask"` or `"auto"`; `mic_mode` = their Phase 2 answer, `"ptt"` or `"open"`.
+- `kimi-visualizer/kimi-visualizer.json`: `name` = the agent's name. `face` = their pick. `bus_dir` = the kimi-voice folder.
+- `kimi-barehands/kimi-barehands.json`: `name` = the agent's name.
+
+Explain the wiring in one sentence as you go: "the voice writes little status notes; the face reads them; that is the whole connection."
+
+Last wire: **make the agent the mechanic.** Append a short section to the `AGENTS.md` in the home folder (for an ADOPTED file, show the person the section and ask before adding it):
+
+> ## You are the mechanic
+> This agent runs on open tools that live in this folder (the memory vault, voice, visualizer, hands). When anything breaks, acts strange, or needs changing, fixing it is YOUR job, not the person's: read the relevant tool's TROUBLESHOOTING.md and README, diagnose, and repair it yourself. Never send the person off to search the internet. If they ask how something works, explain it in plain English.
+
+## Phase 5: The first hello
+
+From the home folder, run `./fullstack-kimi/start.sh` (Windows: `fullstack-kimi\start.bat`). What should happen, and what you verify:
+
+1. The face's server starts and the browser opens on their chosen face, with the agent's name on it.
+2. The voice line warms up and then SPEAKS: "Hello [their name], what are we working on today?" while the face pulses with the words.
+3. Have them hold the talk key and ask their agent anything. Watch the face walk listening, thinking, speaking. First reply lands in a couple of seconds.
+
+If they skipped the voice: the face still opens, and you deliver the greeting yourself, in text, word for word. Nobody's first hello is silent.
+
+If any step fails, each repo has a `TROUBLESHOOTING.md`; work the relevant one with them instead of guessing.
+
+## Phase 6: Hand it over
+
+First, **shut down the finale stack you started in Phase 5**, so the launcher tests below can bind the same ports and nothing you spawned outlives setup. Kill exactly the process IDs you started.
+
+Then, **make the launchers**, so they never have to remember any of this. Shortcuts on their Desktop, named with THEIR agent's name (skip any mode whose pieces they did not install; the Update shortcut is for everyone):
+
+1. **`Chat with <name>`** opens a typed Kimi Code CLI session in the home folder. (macOS: a `.command` file; Windows: a `.bat`.)
+2. **`Talk to <name>`** starts the voice and the face.
+3. **`<name> barehands`** starts the voice and the hands board.
+4. **`Update <name>`** pulls the newest version of every installed piece.
+
+**Every macOS `.command` MUST carry this line right after the shebang, before anything else runs:**
+
+```
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+```
+
+On macOS make each `.command` executable, and warn them once: the first double-click may ask permission; that is macOS being protective, click Open.
+
+Then say the closing pieces, warmly and briefly, WHILE THEY ARE STILL IN THIS SESSION:
+
+- **The daily habit:** the Desktop shortcuts ARE the agent. Chat when they want to type, Talk when they want the voice and the face, barehands when they want the voice and the board.
+- **Closing a window never loses anything:** `kimi --continue` in the home folder reopens the most recent session mid-thought. The agent only wakes up as itself when Kimi Code CLI opens in its home folder.
+- **If anything ever breaks, acts weird, or confuses you:** ask ME. Open the chat and tell me what is wrong, and I will fix it for you. You never need to search the internet or read a manual.
+- **Updating:** double-click `Update <name>` to get the newest version of everything.
+- **Where the knobs live:** each piece's config file sits in its own folder, and each piece's README explains its own tricks.
+
+**Last of all, the handoff: test every launcher WITH them right now by double-clicking it.** Never hand over an untested shortcut.
+
+Then get out of the way. The agent runs itself from here.

--- a/fullstack-kimi/fullstack-kimi.md
+++ b/fullstack-kimi/fullstack-kimi.md
@@ -58,8 +58,10 @@ Collect every remaining answer now, so no later step ever has to ask. Skip anyth
 
 ## Phase 3: Install the pieces
 
-Clone each chosen piece into the home folder as a sibling of this repo, from `github.com/jaredrhod/<name>`:
+Each piece can be used bundled inside this repo or cloned as a sibling from `github.com/jaredrhod/<name>`:
 `kimi-memory-vault`, `kimi-voice`, `kimi-visualizer`, `kimi-barehands`.
+
+If the bundled copy exists, use it. Otherwise clone the repo into the home folder.
 
 **The adoption exceptions, checked before each clone:**
 

--- a/fullstack-kimi/kimi-barehands/README.md
+++ b/fullstack-kimi/kimi-barehands/README.md
@@ -1,0 +1,39 @@
+# kimi-barehands
+
+Hand-controlled spatial board for fullstack-kimi. Use your webcam to move notes and images around the screen with bare hands — no controllers, no headset.
+
+## Run
+
+```bash
+python3 server.py
+```
+
+Then open `http://127.0.0.1:8794/` in Chrome and click **Start barehands**.
+
+## Gestures
+
+- **open** — open palm
+- **pinch** — thumb and index together
+- **point** — only index finger extended
+- **fist** — closed hand
+- **neutral** — none of the above
+
+## How it works
+
+The browser page runs MediaPipe Hands locally. Detected gestures are posted to `/state`, and the server writes them to `.kimi_hands` in the `state_dir` (usually the `kimi-voice` folder so the agent can read them).
+
+## Config
+
+Edit `kimi-barehands.json`:
+
+```json
+{
+  "name": "Kimi",
+  "state_dir": "~/my-kimi-agent/kimi-voice",
+  "port": 8794
+}
+```
+
+## License
+
+AGPL-3.0-or-later. See root `LICENSE`.

--- a/fullstack-kimi/kimi-barehands/TROUBLESHOOTING.md
+++ b/fullstack-kimi/kimi-barehands/TROUBLESHOOTING.md
@@ -1,0 +1,23 @@
+# Troubleshooting
+
+## The page says "no hand" even though my hand is in frame
+
+- Make sure you are in a well-lit room.
+- Move your hand slowly into the center of the frame.
+- MediaPipe needs a clear view of your fingers.
+
+## Gestures flicker
+
+The board waits 200ms before committing a gesture change to reduce jitter. Hold the gesture steady.
+
+## Camera permission denied
+
+Check your browser's site permissions and allow camera access. The camera never leaves your machine.
+
+## The agent doesn't see gestures
+
+Check that `kimi-barehands.json` has the same `state_dir` as `kimi-voice/kimi-voice.json`.
+
+## Works only in Chrome
+
+MediaPipe Hands performs best in Chromium-based browsers. Safari and Firefox may have issues.

--- a/fullstack-kimi/kimi-barehands/kimi-barehands.json
+++ b/fullstack-kimi/kimi-barehands/kimi-barehands.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kimi",
+  "state_dir": "~/my-kimi-agent/kimi-voice",
+  "port": 8794
+}

--- a/fullstack-kimi/kimi-barehands/server.py
+++ b/fullstack-kimi/kimi-barehands/server.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# fullstack-kimi barehands: hand-controlled spatial board.
+# Copyright (C) 2026 Jared Rhodenizer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+A tiny server for the barehands hand-tracking board.
+
+Open Chrome to the printed URL. The page uses your webcam and MediaPipe
+Hands to track your hand, detect gestures, and write state files that the
+agent can read. No controllers, no headset.
+"""
+
+import http.server
+import json
+import os
+import socketserver
+from pathlib import Path
+from urllib.parse import urlparse
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_PORT = 8794
+DEFAULT_STATE_DIR = HERE.parent / "kimi-voice"
+
+
+def load_config():
+    cfg_path = HERE / "kimi-barehands.json"
+    if cfg_path.exists():
+        try:
+            return json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {}
+
+
+def get_state_dir():
+    cfg = load_config()
+    d = cfg.get("state_dir")
+    if d:
+        return Path(d).expanduser()
+    return DEFAULT_STATE_DIR
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path == "/":
+            index = HERE / "static" / "index.html"
+            self.serve_file(index, "text/html")
+            return
+
+        if path == "/config":
+            self.serve_json(load_config())
+            return
+
+        self.directory = str(HERE / "static")
+        super().do_GET()
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/state":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length).decode("utf-8")
+            try:
+                data = json.loads(body)
+            except Exception:
+                data = {}
+            state_dir = get_state_dir()
+            state_dir.mkdir(parents=True, exist_ok=True)
+            (state_dir / ".kimi_hands").write_text(json.dumps(data), encoding="utf-8")
+            self.serve_json({"ok": True})
+            return
+        self.send_error(404)
+
+    def serve_file(self, path, content_type):
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(path.read_bytes())
+
+    def serve_json(self, data):
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    cfg = load_config()
+    port = cfg.get("port", DEFAULT_PORT)
+    with socketserver.TCPServer(("", port), Handler) as httpd:
+        print(f"fullstack-kimi barehands running at http://127.0.0.1:{port}/")
+        print(f"state directory: {get_state_dir()}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/fullstack-kimi/kimi-barehands/static/index.html
+++ b/fullstack-kimi/kimi-barehands/static/index.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>barehands | fullstack-kimi</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: #000; color: #fff; font-family: system-ui, sans-serif; overflow: hidden; }
+    #video { position: fixed; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; transform: scaleX(-1); opacity: 0.4; }
+    #canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; }
+    #hud {
+      position: fixed; top: 1rem; left: 0; width: 100%; text-align: center;
+      pointer-events: none; text-shadow: 0 0 10px #000;
+    }
+    #gesture { font-size: 2rem; color: #0ff; }
+    #status { font-size: 1rem; color: #aaa; margin-top: 0.5rem; }
+    #start {
+      position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
+      background: #000c; z-index: 10;
+    }
+    button { padding: 1rem 2rem; font-size: 1.2rem; background: #0ff; color: #000; border: none; border-radius: 8px; cursor: pointer; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/control_utils/control_utils.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js" crossorigin="anonymous"></script>
+</head>
+<body>
+  <video id="video" playsinline></video>
+  <canvas id="canvas"></canvas>
+  <div id="hud">
+    <div id="gesture">—</div>
+    <div id="status">Click start to enable camera</div>
+  </div>
+  <div id="start"><button id="startBtn">Start barehands</button></div>
+
+  <script>
+    const video = document.getElementById('video');
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const gestureEl = document.getElementById('gesture');
+    const statusEl = document.getElementById('status');
+    const startBtn = document.getElementById('startBtn');
+    const startOverlay = document.getElementById('start');
+
+    let width, height;
+    function resize() { width = canvas.width = window.innerWidth; height = canvas.height = window.innerHeight; }
+    window.addEventListener('resize', resize); resize();
+
+    function dist(a, b) { return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2); }
+
+    function detectGesture(landmarks) {
+      const wrist = landmarks[0];
+      const tips = [landmarks[4], landmarks[8], landmarks[12], landmarks[16], landmarks[20]];
+      const bases = [landmarks[2], landmarks[5], landmarks[9], landmarks[13], landmarks[17]];
+      const extended = tips.map((tip, i) => dist(tip, wrist) > dist(bases[i], wrist) * 1.3);
+
+      // Pinch: thumb tip close to index tip
+      if (dist(landmarks[4], landmarks[8]) < 0.05) return 'pinch';
+
+      // Point: only index extended
+      if (extended[1] && !extended[2] && !extended[3] && !extended[4]) return 'point';
+
+      // Open palm: all fingers extended
+      if (extended.every(Boolean)) return 'open';
+
+      // Fist: no fingers extended
+      if (!extended.some(Boolean)) return 'fist';
+
+      return 'neutral';
+    }
+
+    let lastGesture = 'neutral';
+    let gestureStart = 0;
+    async function postState(gesture, hand) {
+      const payload = { gesture, hand, timestamp: Date.now() };
+      try { await fetch('/state', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }); } catch (e) {}
+    }
+
+    function onResults(results) {
+      ctx.clearRect(0, 0, width, height);
+      let gesture = 'neutral';
+      if (results.multiHandLandmarks && results.multiHandLandmarks.length > 0) {
+        const landmarks = results.multiHandLandmarks[0];
+        drawConnectors(ctx, landmarks, HAND_CONNECTIONS, {color: '#00ffff', lineWidth: 2});
+        drawLandmarks(ctx, landmarks, {color: '#ff00ff', lineWidth: 1, radius: 4});
+        gesture = detectGesture(landmarks);
+      }
+      gestureEl.textContent = gesture;
+      statusEl.textContent = results.multiHandLandmarks ? 'hand detected' : 'no hand';
+
+      if (gesture !== lastGesture) {
+        lastGesture = gesture;
+        gestureStart = Date.now();
+      }
+      // Hold for 200ms before posting to reduce jitter
+      if (Date.now() - gestureStart > 200) {
+        postState(gesture, results.multiHandLandmarks ? 'right' : 'none');
+      }
+    }
+
+    const hands = new Hands({locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`});
+    hands.setOptions({ maxNumHands: 1, modelComplexity: 1, minDetectionConfidence: 0.5, minTrackingConfidence: 0.5 });
+    hands.onResults(onResults);
+
+    startBtn.addEventListener('click', async () => {
+      startOverlay.style.display = 'none';
+      statusEl.textContent = 'starting camera...';
+      const camera = new Camera(video, { onFrame: async () => { await hands.send({image: video}); }, width: 640, height: 480 });
+      await camera.start();
+    });
+  </script>
+</body>
+</html>

--- a/fullstack-kimi/kimi-memory-vault/README.md
+++ b/fullstack-kimi/kimi-memory-vault/README.md
@@ -1,0 +1,49 @@
+# kimi-memory-vault
+
+Persistent memory for fullstack-kimi. A folder of plain Markdown files that the agent reads and writes.
+
+## Vault layout
+
+```
+vault/
+├── identity.md        # Agent personality and role
+├── inbox.md           # Quick captures
+├── sessions/          # Daily conversation logs
+├── people/            # People the user mentions
+├── projects/          # Active projects
+└── topics/            # Topics, lessons, reference notes
+```
+
+## Tools
+
+The agent receives these tools in `tools/memory_tools.json`:
+
+- `memory_search(query)` — find notes
+- `memory_read(path)` — read a note
+- `memory_write(path, content)` — write a note
+- `memory_inbox(text)` — quick capture
+- `memory_session(text)` — append to today's log
+
+## Setup
+
+Run once to create the vault:
+
+```bash
+python3 memory.py
+```
+
+## Config
+
+Edit `kimi-memory-vault.json`:
+
+```json
+{
+  "vault_dir": "~/my-kimi-agent/vault",
+  "agent_name": "Kimi",
+  "daily_note_format": "sessions/%Y-%m-%d.md"
+}
+```
+
+## License
+
+AGPL-3.0-or-later. See root `LICENSE`.

--- a/fullstack-kimi/kimi-memory-vault/TROUBLESHOOTING.md
+++ b/fullstack-kimi/kimi-memory-vault/TROUBLESHOOTING.md
@@ -1,0 +1,17 @@
+# Troubleshooting
+
+## The agent says it can't find memory tools
+
+Make sure `kimi-voice/agent.py` is loading `tools/memory_tools.json` and passing the tool definitions to the Kimi API.
+
+## Notes are not being saved
+
+Check that `vault_dir` in `kimi-memory-vault.json` points to a writable path. The default is `~/my-kimi-agent/vault`.
+
+## The agent reads stale notes
+
+The agent searches the vault on demand. If a note was updated recently, the next search will see it.
+
+## Vault path errors
+
+All note paths are vault-relative and must stay inside the vault. Paths with `..` are rejected.

--- a/fullstack-kimi/kimi-memory-vault/kimi-memory-vault.json
+++ b/fullstack-kimi/kimi-memory-vault/kimi-memory-vault.json
@@ -1,0 +1,6 @@
+{
+  "vault_dir": "~/my-kimi-agent/vault",
+  "agent_name": "Kimi",
+  "owner_name": "",
+  "daily_note_format": "sessions/%Y-%m-%d.md"
+}

--- a/fullstack-kimi/kimi-memory-vault/memory.py
+++ b/fullstack-kimi/kimi-memory-vault/memory.py
@@ -1,0 +1,135 @@
+# fullstack-kimi memory vault: persistent notes for your agent.
+# Copyright (C) 2026 Jared Rhodenizer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Core memory operations for the fullstack-kimi memory vault.
+
+The vault is a folder of plain Markdown files. The agent reads and writes
+these files to remember the user, projects, and conversations across sessions.
+"""
+
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+def load_config():
+    cfg_path = Path(__file__).parent / "kimi-memory-vault.json"
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    cfg["vault_dir"] = str(Path(cfg["vault_dir"]).expanduser())
+    return cfg
+
+
+def ensure_vault():
+    cfg = load_config()
+    vault = Path(cfg["vault_dir"])
+    for sub in ("sessions", "people", "projects", "topics"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    inbox = vault / "inbox.md"
+    if not inbox.exists():
+        inbox.write_text("# Inbox\n\nQuick captures go here.\n", encoding="utf-8")
+    identity = vault / "identity.md"
+    if not identity.exists():
+        identity.write_text(
+            f"# {cfg.get('agent_name', 'Agent')}\n\n"
+            "Role and personality for the agent go here.\n",
+            encoding="utf-8",
+        )
+    return vault
+
+
+def _vault_dir():
+    return Path(load_config()["vault_dir"])
+
+
+def search_notes(query: str, limit: int = 10):
+    """Search all markdown notes for a query string."""
+    vault = _vault_dir()
+    results = []
+    query_lower = query.lower()
+    for path in vault.rglob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+            if query_lower in text.lower():
+                # Return a snippet around the match.
+                idx = text.lower().find(query_lower)
+                start = max(0, idx - 120)
+                end = min(len(text), idx + 240)
+                snippet = text[start:end].replace("\n", " ")
+                results.append({
+                    "file": str(path.relative_to(vault)),
+                    "snippet": snippet,
+                })
+        except Exception:
+            continue
+    return results[:limit]
+
+
+def read_note(path: str) -> str:
+    """Read a single note by vault-relative path."""
+    vault = _vault_dir()
+    note_path = vault / path
+    note_path = note_path.resolve()
+    if not str(note_path).startswith(str(vault.resolve())):
+        raise ValueError("path escapes vault")
+    if not note_path.exists():
+        return ""
+    return note_path.read_text(encoding="utf-8")
+
+
+def write_note(path: str, content: str) -> str:
+    """Write a note at a vault-relative path. Creates parent folders."""
+    vault = _vault_dir()
+    note_path = vault / path
+    note_path = note_path.resolve()
+    if not str(note_path).startswith(str(vault.resolve())):
+        raise ValueError("path escapes vault")
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(content, encoding="utf-8")
+    return str(note_path.relative_to(vault))
+
+
+def append_to_inbox(text: str):
+    """Append a quick capture to inbox.md."""
+    vault = _vault_dir()
+    inbox = vault / "inbox.md"
+    inbox.write_text(
+        inbox.read_text(encoding="utf-8") + f"\n- {datetime.now().isoformat()}: {text}\n",
+        encoding="utf-8",
+    )
+    return str(inbox.relative_to(vault))
+
+
+def add_session_note(text: str):
+    """Append a summary to today's session note."""
+    vault = _vault_dir()
+    cfg = load_config()
+    date_path = datetime.now().strftime(cfg.get("daily_note_format", "sessions/%Y-%m-%d.md"))
+    note_path = vault / date_path
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    header = f"# Session {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n"
+    if not note_path.exists():
+        note_path.write_text(header, encoding="utf-8")
+    note_path.write_text(
+        note_path.read_text(encoding="utf-8") + f"\n{text}\n",
+        encoding="utf-8",
+    )
+    return str(note_path.relative_to(vault))
+
+
+def list_notes(folder: str = ""):
+    """List notes in a vault-relative folder."""
+    vault = _vault_dir()
+    target = vault / folder if folder else vault
+    notes = []
+    for path in target.rglob("*.md"):
+        notes.append(str(path.relative_to(vault)))
+    return sorted(notes)
+
+
+if __name__ == "__main__":
+    ensure_vault()
+    print(f"vault ready at {_vault_dir()}")

--- a/fullstack-kimi/kimi-memory-vault/tools/memory_tools.json
+++ b/fullstack-kimi/kimi-memory-vault/tools/memory_tools.json
@@ -1,0 +1,95 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "memory_search",
+      "description": "Search the agent's memory vault for notes matching a query. Use this when the user refers to something from a previous conversation, project, person, or topic.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Keywords to search for in the vault."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of results to return."
+          }
+        },
+        "required": ["query"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "memory_read",
+      "description": "Read a single note from the memory vault by its vault-relative path.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Vault-relative path to the note, e.g. 'projects/website.md'."
+          }
+        },
+        "required": ["path"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "memory_write",
+      "description": "Write or overwrite a note in the memory vault. Use this to remember facts, decisions, project plans, or session summaries.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Vault-relative path, e.g. 'people/alice.md' or 'topics/rust.md'."
+          },
+          "content": {
+            "type": "string",
+            "description": "Full Markdown content of the note."
+          }
+        },
+        "required": ["path", "content"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "memory_inbox",
+      "description": "Append a quick capture to the inbox for later processing.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Short text to capture."
+          }
+        },
+        "required": ["text"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "memory_session",
+      "description": "Append a summary to today's session note. Use this at the end of a conversation to record what happened.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Summary of the session or turn to remember."
+          }
+        },
+        "required": ["text"]
+      }
+    }
+  }
+]

--- a/fullstack-kimi/kimi-visualizer/README.md
+++ b/fullstack-kimi/kimi-visualizer/README.md
@@ -1,0 +1,44 @@
+# kimi-visualizer
+
+The browser-based face for fullstack-kimi. It shows an animated visualizer that idles, listens, thinks, and speaks in sync with the agent's voice state.
+
+## Faces
+
+- **board** — living circuit board (default)
+- **radial** — concentric wave rings
+- **rain** — digital rain
+- **neural** — pulsing neuron network
+
+## Run
+
+```bash
+python3 server.py
+```
+
+Then open http://127.0.0.1:8790/ and pick a face.
+
+## How it works
+
+The server reads state files from the `bus_dir` (usually the `kimi-voice` folder):
+
+- `.kimi_state` — JSON like `{"state": "listening|thinking|speaking|idle", "text": "..."}`
+- `.kimi_waveform` — JSON like `{"levels": [0.0, 0.2, ...]}`
+
+The browser polls `/state` several times a second and animates the face accordingly.
+
+## Config
+
+Edit `kimi-visualizer.json`:
+
+```json
+{
+  "name": "Kimi",
+  "face": "board",
+  "bus_dir": "~/my-kimi-agent/kimi-voice",
+  "port": 8790
+}
+```
+
+## License
+
+AGPL-3.0-or-later. See root `LICENSE`.

--- a/fullstack-kimi/kimi-visualizer/TROUBLESHOOTING.md
+++ b/fullstack-kimi/kimi-visualizer/TROUBLESHOOTING.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## The browser opens to a gallery instead of a face
+
+The root page is the gallery. Pick a face, or go directly to `/faces/board/`.
+
+## The face is stuck at idle
+
+1. Check that `kimi-visualizer.json` has the right `bus_dir` pointing at your voice bridge folder.
+2. Make sure the voice bridge is writing `.kimi_state` and `.kimi_waveform` files.
+3. Restart the visualizer server after any config change.
+
+## The face never shows the agent's name
+
+The name comes from `/config`, which reads `kimi-visualizer.json`. Make sure the `name` field is set and restart the server.
+
+## Port already in use
+
+Either another visualizer is running, or something else is using port 8790. Close the other process or change `port` in `kimi-visualizer.json`.

--- a/fullstack-kimi/kimi-visualizer/faces/board/index.html
+++ b/fullstack-kimi/kimi-visualizer/faces/board/index.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>board | fullstack-kimi</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: #020204; overflow: hidden; }
+    canvas { display: block; }
+    #hud {
+      position: fixed; bottom: 2rem; left: 0; width: 100%;
+      text-align: center; color: #00f0ff; font-family: system-ui, sans-serif;
+      pointer-events: none; text-shadow: 0 0 10px #00f0ff88;
+    }
+    #name { font-size: 1.5rem; letter-spacing: 0.2em; text-transform: uppercase; }
+    #text { font-size: 1rem; margin-top: 0.5rem; min-height: 1.5em; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <canvas id="face"></canvas>
+  <div id="hud">
+    <div id="name">Kimi</div>
+    <div id="text"></div>
+  </div>
+  <script>
+    const canvas = document.getElementById('face');
+    const ctx = canvas.getContext('2d');
+    const nameEl = document.getElementById('name');
+    const textEl = document.getElementById('text');
+
+    let width, height;
+    let state = 'idle';
+    let waveform = new Array(16).fill(0);
+    let text = '';
+    let time = 0;
+
+    function resize() {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    // Circuit nodes
+    const nodes = [];
+    for (let i = 0; i < 40; i++) {
+      nodes.push({
+        x: Math.random(), y: Math.random(),
+        r: 2 + Math.random() * 3,
+        pulse: Math.random() * Math.PI * 2,
+        speed: 0.02 + Math.random() * 0.04
+      });
+    }
+
+    async function fetchState() {
+      try {
+        const r = await fetch('/state');
+        const d = await r.json();
+        state = d.state || 'idle';
+        waveform = d.waveform || waveform;
+        text = d.text || '';
+      } catch (e) {
+        state = 'idle';
+      }
+      try {
+        const r = await fetch('/config');
+        const d = await r.json();
+        if (d.name) nameEl.textContent = d.name;
+      } catch (e) {}
+      textEl.textContent = text;
+    }
+    setInterval(fetchState, 100);
+    fetchState();
+
+    function energy() {
+      if (state === 'speaking') return 1.0;
+      if (state === 'listening') return 0.7;
+      if (state === 'thinking') return 0.5;
+      return 0.2;
+    }
+
+    function color() {
+      if (state === 'speaking') return '#00f0ff';
+      if (state === 'listening') return '#00ff88';
+      if (state === 'thinking') return '#ffaa00';
+      return '#4444ff';
+    }
+
+    function draw() {
+      time += 0.02;
+      ctx.fillStyle = '#020204';
+      ctx.fillRect(0, 0, width, height);
+
+      const e = energy();
+      const c = color();
+      const cx = width / 2;
+      const cy = height / 2;
+
+      // Draw traces between nearby nodes
+      ctx.strokeStyle = c + '22';
+      ctx.lineWidth = 1;
+      for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+          const x1 = nodes[i].x * width, y1 = nodes[i].y * height;
+          const x2 = nodes[j].x * width, y2 = nodes[j].y * height;
+          const dx = x1 - x2, dy = y1 - y2;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < 180) {
+            ctx.globalAlpha = (1 - dist / 180) * 0.5 * e;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+            ctx.stroke();
+          }
+        }
+      }
+      ctx.globalAlpha = 1;
+
+      // Draw nodes
+      for (const n of nodes) {
+        n.pulse += n.speed * (0.5 + e);
+        const x = n.x * width;
+        const y = n.y * height;
+        const pulse = Math.sin(n.pulse) * 0.5 + 0.5;
+        const r = n.r + pulse * 2 * e;
+        ctx.beginPath();
+        ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fillStyle = c;
+        ctx.shadowBlur = 10 * e;
+        ctx.shadowColor = c;
+        ctx.fill();
+      }
+      ctx.shadowBlur = 0;
+
+      // Central chip ring
+      const ringSize = 80 + waveform.reduce((a, b) => a + b, 0) * 30;
+      ctx.strokeStyle = c;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cx, cy, ringSize, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // Rotating ring segment
+      ctx.beginPath();
+      ctx.arc(cx, cy, ringSize + 10, time * (0.5 + e), time * (0.5 + e) + Math.PI);
+      ctx.strokeStyle = c;
+      ctx.lineWidth = 4;
+      ctx.stroke();
+
+      requestAnimationFrame(draw);
+    }
+    draw();
+  </script>
+</body>
+</html>

--- a/fullstack-kimi/kimi-visualizer/faces/neural/index.html
+++ b/fullstack-kimi/kimi-visualizer/faces/neural/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>neural | fullstack-kimi</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: #020206; overflow: hidden; }
+    canvas { display: block; }
+    #hud {
+      position: fixed; bottom: 2rem; left: 0; width: 100%;
+      text-align: center; color: #aa88ff; font-family: system-ui, sans-serif;
+      pointer-events: none; text-shadow: 0 0 10px #aa88ff88;
+    }
+    #name { font-size: 1.5rem; letter-spacing: 0.2em; text-transform: uppercase; }
+    #text { font-size: 1rem; margin-top: 0.5rem; min-height: 1.5em; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <canvas id="face"></canvas>
+  <div id="hud">
+    <div id="name">Kimi</div>
+    <div id="text"></div>
+  </div>
+  <script>
+    const canvas = document.getElementById('face');
+    const ctx = canvas.getContext('2d');
+    const nameEl = document.getElementById('name');
+    const textEl = document.getElementById('text');
+
+    let width, height, state = 'idle', waveform = new Array(16).fill(0), text = '', time = 0;
+    const neurons = [];
+    for (let i = 0; i < 24; i++) neurons.push({ x: Math.random(), y: Math.random(), z: Math.random(), phase: Math.random() * Math.PI * 2 });
+
+    function resize() { width = canvas.width = window.innerWidth; height = canvas.height = window.innerHeight; }
+    window.addEventListener('resize', resize); resize();
+
+    async function fetchState() {
+      try { const d = await (await fetch('/state')).json(); state = d.state || 'idle'; waveform = d.waveform || waveform; text = d.text || ''; } catch (e) { state = 'idle'; }
+      try { const d = await (await fetch('/config')).json(); if (d.name) nameEl.textContent = d.name; } catch (e) {}
+      textEl.textContent = text;
+    }
+    setInterval(fetchState, 100); fetchState();
+
+    function energy() { return state === 'speaking' ? 1 : state === 'listening' ? 0.75 : state === 'thinking' ? 0.55 : 0.2; }
+    function color() { return state === 'speaking' ? '#aa88ff' : state === 'listening' ? '#88aaff' : state === 'thinking' ? '#ff88aa' : '#5555aa'; }
+
+    function project(n) {
+      const cx = width / 2, cy = height / 2;
+      const scale = 0.6 + n.z * 0.4;
+      const x = cx + (n.x - 0.5) * width * scale;
+      const y = cy + (n.y - 0.5) * height * scale;
+      return { x, y, scale };
+    }
+
+    function draw() {
+      time += 0.02;
+      ctx.fillStyle = '#020206'; ctx.fillRect(0, 0, width, height);
+      const e = energy(), c = color();
+
+      for (const n of neurons) n.phase += 0.03 * (0.5 + e);
+
+      // Connections
+      ctx.strokeStyle = c;
+      for (let i = 0; i < neurons.length; i++) {
+        for (let j = i + 1; j < neurons.length; j++) {
+          const a = project(neurons[i]), b = project(neurons[j]);
+          const dx = a.x - b.x, dy = a.y - b.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < 250) {
+            ctx.globalAlpha = (1 - dist / 250) * 0.4 * e;
+            ctx.lineWidth = 1;
+            ctx.beginPath(); ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y); ctx.stroke();
+          }
+        }
+      }
+
+      // Neurons
+      for (let i = 0; i < neurons.length; i++) {
+        const n = neurons[i];
+        const p = project(n);
+        const pulse = Math.sin(n.phase) * 0.5 + 0.5;
+        const r = 4 + pulse * 6 * e + waveform[i % waveform.length] * 8;
+        ctx.beginPath(); ctx.arc(p.x, p.y, r, 0, Math.PI * 2);
+        ctx.fillStyle = c;
+        ctx.shadowBlur = 15 * e;
+        ctx.shadowColor = c;
+        ctx.globalAlpha = 0.7 + pulse * 0.3;
+        ctx.fill();
+      }
+      ctx.shadowBlur = 0; ctx.globalAlpha = 1;
+      requestAnimationFrame(draw);
+    }
+    draw();
+  </script>
+</body>
+</html>

--- a/fullstack-kimi/kimi-visualizer/faces/radial/index.html
+++ b/fullstack-kimi/kimi-visualizer/faces/radial/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>radial | fullstack-kimi</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: #050508; overflow: hidden; }
+    canvas { display: block; }
+    #hud {
+      position: fixed; bottom: 2rem; left: 0; width: 100%;
+      text-align: center; color: #ff66cc; font-family: system-ui, sans-serif;
+      pointer-events: none; text-shadow: 0 0 10px #ff66cc88;
+    }
+    #name { font-size: 1.5rem; letter-spacing: 0.2em; text-transform: uppercase; }
+    #text { font-size: 1rem; margin-top: 0.5rem; min-height: 1.5em; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <canvas id="face"></canvas>
+  <div id="hud">
+    <div id="name">Kimi</div>
+    <div id="text"></div>
+  </div>
+  <script>
+    const canvas = document.getElementById('face');
+    const ctx = canvas.getContext('2d');
+    const nameEl = document.getElementById('name');
+    const textEl = document.getElementById('text');
+
+    let width, height, state = 'idle', waveform = new Array(16).fill(0), text = '', time = 0;
+
+    function resize() { width = canvas.width = window.innerWidth; height = canvas.height = window.innerHeight; }
+    window.addEventListener('resize', resize); resize();
+
+    async function fetchState() {
+      try { const d = await (await fetch('/state')).json(); state = d.state || 'idle'; waveform = d.waveform || waveform; text = d.text || ''; } catch (e) { state = 'idle'; }
+      try { const d = await (await fetch('/config')).json(); if (d.name) nameEl.textContent = d.name; } catch (e) {}
+      textEl.textContent = text;
+    }
+    setInterval(fetchState, 100); fetchState();
+
+    function energy() { return state === 'speaking' ? 1 : state === 'listening' ? 0.75 : state === 'thinking' ? 0.5 : 0.2; }
+    function color() { return state === 'speaking' ? '#ff66cc' : state === 'listening' ? '#66ffcc' : state === 'thinking' ? '#ffcc66' : '#6666ff'; }
+
+    function draw() {
+      time += 0.02;
+      ctx.fillStyle = '#050508'; ctx.fillRect(0, 0, width, height);
+      const cx = width / 2, cy = height / 2;
+      const e = energy(), c = color();
+      const rings = 8;
+      for (let i = 0; i < rings; i++) {
+        const baseR = 40 + i * 45;
+        const amp = waveform[i % waveform.length] * 40 * e;
+        const r = baseR + amp;
+        const alpha = 0.1 + (1 - i / rings) * 0.5 * e;
+        ctx.strokeStyle = c;
+        ctx.globalAlpha = alpha;
+        ctx.lineWidth = 2 + e * 2;
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, time * (0.2 + i * 0.05) * (0.5 + e), time * (0.2 + i * 0.05) * (0.5 + e) + Math.PI * 1.5);
+        ctx.stroke();
+      }
+      ctx.globalAlpha = 1;
+      requestAnimationFrame(draw);
+    }
+    draw();
+  </script>
+</body>
+</html>

--- a/fullstack-kimi/kimi-visualizer/faces/rain/index.html
+++ b/fullstack-kimi/kimi-visualizer/faces/rain/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>rain | fullstack-kimi</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: #000; overflow: hidden; }
+    canvas { display: block; }
+    #hud {
+      position: fixed; bottom: 2rem; left: 0; width: 100%;
+      text-align: center; color: #00ff41; font-family: monospace;
+      pointer-events: none; text-shadow: 0 0 10px #00ff4188;
+    }
+    #name { font-size: 1.5rem; letter-spacing: 0.2em; text-transform: uppercase; }
+    #text { font-size: 1rem; margin-top: 0.5rem; min-height: 1.5em; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <canvas id="face"></canvas>
+  <div id="hud">
+    <div id="name">Kimi</div>
+    <div id="text"></div>
+  </div>
+  <script>
+    const canvas = document.getElementById('face');
+    const ctx = canvas.getContext('2d');
+    const nameEl = document.getElementById('name');
+    const textEl = document.getElementById('text');
+
+    let width, height, state = 'idle', waveform = new Array(16).fill(0), text = '';
+    const cols = 40;
+    let drops = [];
+
+    function resize() {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+      drops = new Array(Math.floor(width / 20)).fill(0).map(() => Math.random() * -100);
+    }
+    window.addEventListener('resize', resize); resize();
+
+    async function fetchState() {
+      try { const d = await (await fetch('/state')).json(); state = d.state || 'idle'; waveform = d.waveform || waveform; text = d.text || ''; } catch (e) { state = 'idle'; }
+      try { const d = await (await fetch('/config')).json(); if (d.name) nameEl.textContent = d.name; } catch (e) {}
+      textEl.textContent = text;
+    }
+    setInterval(fetchState, 100); fetchState();
+
+    function energy() { return state === 'speaking' ? 1 : state === 'listening' ? 0.8 : state === 'thinking' ? 0.5 : 0.2; }
+    function color() { return state === 'speaking' ? '#00ff41' : state === 'listening' ? '#00ffff' : state === 'thinking' ? '#ffff00' : '#008800'; }
+
+    const chars = "01アイウエオカキクケコサシスセソ";
+    function draw() {
+      const e = energy(), c = color();
+      ctx.fillStyle = 'rgba(0,0,0,0.15)';
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.font = '14px monospace';
+      const colWidth = width / drops.length;
+      for (let i = 0; i < drops.length; i++) {
+        const speed = 2 + e * 6 + waveform[i % waveform.length] * 8;
+        const x = i * colWidth;
+        const y = drops[i] * 18;
+        const ch = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillStyle = c;
+        ctx.globalAlpha = 0.3 + e * 0.7;
+        ctx.fillText(ch, x, y);
+        if (y > height && Math.random() > 0.975) drops[i] = 0;
+        drops[i] += speed * 0.05;
+      }
+      ctx.globalAlpha = 1;
+      requestAnimationFrame(draw);
+    }
+    draw();
+  </script>
+</body>
+</html>

--- a/fullstack-kimi/kimi-visualizer/kimi-visualizer.json
+++ b/fullstack-kimi/kimi-visualizer/kimi-visualizer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Kimi",
+  "face": "board",
+  "bus_dir": "~/my-kimi-agent/kimi-voice",
+  "port": 8790
+}

--- a/fullstack-kimi/kimi-visualizer/server.py
+++ b/fullstack-kimi/kimi-visualizer/server.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# fullstack-kimi visualizer: a browser-based face for your agent.
+# Copyright (C) 2026 Jared Rhodenizer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+A tiny static server + state API for the fullstack-kimi face.
+
+The visualizer reads little state files dropped by the voice bridge
+(usually the kimi-voice folder) and animates the browser face to match:
+    idle -> listening -> thinking -> speaking
+
+Run from the visualizer folder:
+    python3 server.py
+
+Then open http://127.0.0.1:8790/ and pick a face.
+"""
+
+import http.server
+import json
+import os
+import socketserver
+from pathlib import Path
+from urllib.parse import urlparse
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_PORT = 8790
+DEFAULT_BUS_DIR = HERE.parent / "kimi-voice"
+
+
+def load_config():
+    cfg_path = HERE / "kimi-visualizer.json"
+    if cfg_path.exists():
+        try:
+            return json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {}
+
+
+def get_bus_dir():
+    cfg = load_config()
+    bus = cfg.get("bus_dir")
+    if bus:
+        return Path(bus).expanduser()
+    return DEFAULT_BUS_DIR
+
+
+def read_state():
+    """Read the current voice state from the bus directory."""
+    bus = get_bus_dir()
+    state_file = bus / ".kimi_state"
+    waveform_file = bus / ".kimi_waveform"
+
+    result = {
+        "state": "idle",
+        "text": "",
+        "waveform": [0.0] * 16,
+    }
+
+    if state_file.exists():
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+            result["state"] = data.get("state", "idle")
+            result["text"] = data.get("text", "")
+        except Exception:
+            pass
+
+    if waveform_file.exists():
+        try:
+            data = json.loads(waveform_file.read_text(encoding="utf-8"))
+            result["waveform"] = data.get("levels", [0.0] * 16)
+        except Exception:
+            pass
+
+    return result
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        # Keep the terminal quiet except for real errors.
+        pass
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path == "/":
+            self.serve_gallery()
+            return
+
+        if path == "/state":
+            self.serve_json(read_state())
+            return
+
+        if path == "/config":
+            self.serve_json(load_config())
+            return
+
+        if path.startswith("/faces/"):
+            # /faces/board/ -> serve faces/board/index.html
+            parts = path.strip("/").split("/")
+            if len(parts) == 3 and parts[2] == "":
+                face_name = parts[1]
+                index = HERE / "faces" / face_name / "index.html"
+                if index.exists():
+                    self.serve_file(index, "text/html")
+                    return
+
+        # Fall back to static files under faces/.
+        self.directory = str(HERE)
+        super().do_GET()
+
+    def serve_file(self, path, content_type):
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(path.read_bytes())
+
+    def serve_json(self, data):
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def serve_gallery(self):
+        faces = []
+        faces_dir = HERE / "faces"
+        if faces_dir.exists():
+            for item in sorted(faces_dir.iterdir()):
+                if item.is_dir() and (item / "index.html").exists():
+                    faces.append(item.name)
+
+        html = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fullstack-kimi | pick a face</title>
+  <style>
+    body {{
+      margin: 0; height: 100vh; background: #050505; color: #e0e0e0;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+    }}
+    h1 {{ font-weight: 300; letter-spacing: 0.1em; margin-bottom: 2rem; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; max-width: 800px; width: 90%; }}
+    a {{
+      display: block; padding: 2rem; text-align: center; text-decoration: none;
+      color: #0ff; border: 1px solid #0ff3; border-radius: 12px;
+      background: #0ff05; transition: all 0.2s;
+    }}
+    a:hover {{ background: #0ff1; transform: translateY(-3px); }}
+    .name {{ font-size: 1.2rem; text-transform: capitalize; }}
+  </style>
+</head>
+<body>
+  <h1>fullstack-kimi</h1>
+  <div class="grid">
+    {''.join(f'<a href="/faces/{f}/"><div class="name">{f}</div></a>' for f in faces)}
+  </div>
+</body>
+</html>"""
+        self.serve_response(html, "text/html")
+
+    def serve_response(self, body, content_type):
+        data = body.encode("utf-8") if isinstance(body, str) else body
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def main():
+    config = load_config()
+    port = config.get("port", DEFAULT_PORT)
+
+    with socketserver.TCPServer(("", port), Handler) as httpd:
+        print(f"fullstack-kimi visualizer running at http://127.0.0.1:{port}/")
+        print(f"bus directory: {get_bus_dir()}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/fullstack-kimi/kimi-voice/README.md
+++ b/fullstack-kimi/kimi-voice/README.md
@@ -1,0 +1,69 @@
+# kimi-voice
+
+The voice bridge for fullstack-kimi. Hold a key, speak, and the agent answers out loud while the face animates.
+
+## Quick start
+
+1. Set your Moonshot API key:
+
+```bash
+export MOONSHOT_API_KEY="your-key"
+```
+
+2. Install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+3. Run:
+
+```bash
+./run.sh
+```
+
+Hold the configured talk key (default: `home`) to speak. Release to send. Ctrl-C to quit.
+
+## How it works
+
+1. `audio.py` records while the talk key is held.
+2. `stt.py` transcribes the recording.
+3. `agent.py` sends the text to the Kimi API and gets a reply.
+4. `tts.py` speaks the reply.
+5. `state.py` writes `.kimi_state` and `.kimi_waveform` so `kimi-visualizer` can animate.
+
+## Config
+
+Edit `kimi-voice.json`:
+
+```json
+{
+  "name": "Kimi",
+  "greeting": "Hello there, what are we working on today?",
+  "agent_dir": "~/my-kimi-agent",
+  "bus_dir": "~/my-kimi-agent/kimi-voice",
+  "mic_mode": "ptt",
+  "talk_key": "home",
+  "permission_mode": "ask",
+  "stt": { "engine": "whisper_api", "model": "whisper-1" },
+  "tts": { "engine": "pyttsx3", "rate": 180 },
+  "llm": { "backend": "kimi_api", "model": "kimi-k3" }
+}
+```
+
+## STT engines
+
+- `whisper_api` — OpenAI Whisper API (requires `OPENAI_API_KEY`)
+- `faster_whisper` — local Whisper (requires `faster-whisper` installed)
+
+## TTS engines
+
+- `pyttsx3` — local, offline, works everywhere
+- `edge_tts` — natural cloud voices (requires `edge-tts` and ffmpeg)
+- `say` — macOS built-in
+
+## License
+
+AGPL-3.0-or-later. See root `LICENSE`.

--- a/fullstack-kimi/kimi-voice/TROUBLESHOOTING.md
+++ b/fullstack-kimi/kimi-voice/TROUBLESHOOTING.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+## It says "MOONSHOT_API_KEY not set"
+
+Set the key in your environment:
+
+```bash
+export MOONSHOT_API_KEY="..."
+```
+
+Or put it in `kimi-voice.json` under `llm.api_key`.
+
+## The talk key doesn't do anything
+
+- Make sure `mic_mode` is `ptt` (push-to-talk).
+- Try a different `talk_key`: `home`, `space`, `shift`, `ctrl`, `alt`, or a single letter.
+- If pynput cannot access input devices, the bridge falls back to terminal typing mode.
+
+## I get "No input device"
+
+Your microphone may be in use by another app, or sounddevice cannot see it. Check System Settings → Privacy & Security → Microphone.
+
+## The agent replies but I don't hear anything
+
+- If using `pyttsx3`, make sure your system volume is up.
+- If using `edge_tts`, make sure `ffmpeg` is installed.
+- If using `say`, it only works on macOS.
+
+## The face doesn't move
+
+Check that `kimi-voice.json` has the same `bus_dir` as `kimi-visualizer.json`.
+
+## STT is wrong
+
+- Speak closer to the mic.
+- Use a quieter room.
+- Switch to `faster_whisper` local model for better offline accuracy.

--- a/fullstack-kimi/kimi-voice/agent.py
+++ b/fullstack-kimi/kimi-voice/agent.py
@@ -1,0 +1,52 @@
+# fullstack-kimi voice bridge: agent backend.
+
+from pathlib import Path
+
+from openai import OpenAI
+
+
+class Agent:
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.llm_cfg = cfg.get("llm", {})
+        backend = self.llm_cfg.get("backend", "kimi_api")
+        if backend != "kimi_api":
+            raise ValueError(f"unknown llm backend: {backend}")
+
+        api_key = self.llm_cfg.get("api_key")
+        if not api_key:
+            raise RuntimeError("llm backend 'kimi_api' requires an api_key or MOONSHOT_API_KEY env var")
+
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=self.llm_cfg.get("base_url", "https://api.moonshot.ai/v1"),
+        )
+        self.model = self.llm_cfg.get("model", "kimi-k3")
+        self.name = cfg.get("name", "Kimi")
+        self.messages = []
+        self._load_identity()
+
+    def _load_identity(self):
+        agent_dir = Path(self.cfg.get("agent_dir", "~")).expanduser()
+        identity_text = ""
+        for filename in ("AGENTS.md", "KIMI.md", "SYSTEM.md"):
+            path = agent_dir / filename
+            if path.exists():
+                identity_text += f"\n\n--- {filename} ---\n" + path.read_text(encoding="utf-8")
+        if not identity_text:
+            identity_text = f"You are {self.name}, a helpful AI assistant."
+        self.messages.append({"role": "system", "content": identity_text})
+
+    def respond(self, text: str) -> str:
+        self.messages.append({"role": "user", "content": text})
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=self.messages,
+            max_completion_tokens=1024,
+        )
+        reply = response.choices[0].message.content.strip()
+        self.messages.append({"role": "assistant", "content": reply})
+        # Keep context window bounded roughly.
+        if len(self.messages) > 20:
+            self.messages = [self.messages[0]] + self.messages[-18:]
+        return reply

--- a/fullstack-kimi/kimi-voice/agent.py
+++ b/fullstack-kimi/kimi-voice/agent.py
@@ -1,14 +1,25 @@
-# fullstack-kimi voice bridge: agent backend.
+# fullstack-kimi voice bridge: agent backend with tool use.
 
+import json
+import os
+import subprocess
 from pathlib import Path
 
 from openai import OpenAI
 
+# Import memory tools if the vault is bundled.
+try:
+    import memory
+    MEMORY_AVAILABLE = True
+except Exception:
+    MEMORY_AVAILABLE = False
+
 
 class Agent:
-    def __init__(self, cfg):
+    def __init__(self, cfg, approve_callback=None):
         self.cfg = cfg
         self.llm_cfg = cfg.get("llm", {})
+        self.approve_callback = approve_callback or (lambda _n, _d: True)
         backend = self.llm_cfg.get("backend", "kimi_api")
         if backend != "kimi_api":
             raise ValueError(f"unknown llm backend: {backend}")
@@ -24,29 +35,147 @@ class Agent:
         self.model = self.llm_cfg.get("model", "kimi-k3")
         self.name = cfg.get("name", "Kimi")
         self.messages = []
+        self.tools = []
+        self.tool_map = {}
         self._load_identity()
+        self._load_tools()
 
     def _load_identity(self):
         agent_dir = Path(self.cfg.get("agent_dir", "~")).expanduser()
-        identity_text = ""
+        identity_text = f"You are {self.name}, a helpful AI assistant.\n"
+        identity_text += "You have tools. Use them when they help answer the user.\n"
+        identity_text += "When you write files, prefer Markdown. Keep replies concise when speaking.\n"
         for filename in ("AGENTS.md", "KIMI.md", "SYSTEM.md"):
             path = agent_dir / filename
             if path.exists():
-                identity_text += f"\n\n--- {filename} ---\n" + path.read_text(encoding="utf-8")
-        if not identity_text:
-            identity_text = f"You are {self.name}, a helpful AI assistant."
+                identity_text += f"\n--- {filename} ---\n" + path.read_text(encoding="utf-8")
         self.messages.append({"role": "system", "content": identity_text})
+
+    def _load_tools(self):
+        tool_files = [Path(__file__).parent / "tools" / "system_tools.json"]
+        if MEMORY_AVAILABLE:
+            tool_files.append(Path(__file__).parent.parent / "kimi-memory-vault" / "tools" / "memory_tools.json")
+
+        for tf in tool_files:
+            if tf.exists():
+                defs = json.loads(tf.read_text(encoding="utf-8"))
+                self.tools.extend(defs)
+
+        self.tool_map = {
+            "bash": self._tool_bash,
+            "read_file": self._tool_read_file,
+            "write_file": self._tool_write_file,
+            "memory_search": self._tool_memory_search,
+            "memory_read": self._tool_memory_read,
+            "memory_write": self._tool_memory_write,
+            "memory_inbox": self._tool_memory_inbox,
+            "memory_session": self._tool_memory_session,
+        }
+
+    def _resolve_path(self, path: str) -> Path:
+        p = Path(path).expanduser()
+        if not p.is_absolute():
+            p = Path(self.cfg.get("agent_dir", "~")).expanduser() / p
+        return p.resolve()
+
+    def _tool_bash(self, args: dict) -> str:
+        cmd = args.get("command", "")
+        if not cmd:
+            return "no command provided"
+        try:
+            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+            out = result.stdout
+            if result.stderr:
+                out += "\n" + result.stderr
+            if result.returncode != 0:
+                out += f"\n[exit code {result.returncode}]"
+            return out[:4000]
+        except Exception as exc:
+            return f"error: {exc}"
+
+    def _tool_read_file(self, args: dict) -> str:
+        p = self._resolve_path(args.get("path", ""))
+        try:
+            return p.read_text(encoding="utf-8")[:8000]
+        except Exception as exc:
+            return f"error reading {p}: {exc}"
+
+    def _tool_write_file(self, args: dict) -> str:
+        p = self._resolve_path(args.get("path", ""))
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(args.get("content", ""), encoding="utf-8")
+            return f"wrote {p}"
+        except Exception as exc:
+            return f"error writing {p}: {exc}"
+
+    def _tool_memory_search(self, args: dict) -> str:
+        if not MEMORY_AVAILABLE:
+            return "memory vault not available"
+        results = memory.search_notes(args.get("query", ""), args.get("limit", 10))
+        return json.dumps(results, ensure_ascii=False)
+
+    def _tool_memory_read(self, args: dict) -> str:
+        if not MEMORY_AVAILABLE:
+            return "memory vault not available"
+        return memory.read_note(args.get("path", ""))
+
+    def _tool_memory_write(self, args: dict) -> str:
+        if not MEMORY_AVAILABLE:
+            return "memory vault not available"
+        return memory.write_note(args.get("path", ""), args.get("content", ""))
+
+    def _tool_memory_inbox(self, args: dict) -> str:
+        if not MEMORY_AVAILABLE:
+            return "memory vault not available"
+        return memory.append_to_inbox(args.get("text", ""))
+
+    def _tool_memory_session(self, args: dict) -> str:
+        if not MEMORY_AVAILABLE:
+            return "memory vault not available"
+        return memory.add_session_note(args.get("text", ""))
+
+    def _needs_approval(self, name: str) -> bool:
+        return name in ("bash", "write_file", "memory_write", "memory_inbox", "memory_session")
+
+    def _execute_tool(self, call) -> dict:
+        name = call.function.name
+        args = json.loads(call.function.arguments or "{}")
+        description = f"{name}({json.dumps(args)})"
+
+        if self._needs_approval(name):
+            if not self.approve_callback(name, description):
+                return {"role": "tool", "tool_call_id": call.id, "content": "user denied permission"}
+
+        handler = self.tool_map.get(name)
+        if not handler:
+            return {"role": "tool", "tool_call_id": call.id, "content": f"unknown tool: {name}"}
+        try:
+            result = handler(args)
+        except Exception as exc:
+            result = f"error: {exc}"
+        return {"role": "tool", "tool_call_id": call.id, "content": str(result)[:8000]}
 
     def respond(self, text: str) -> str:
         self.messages.append({"role": "user", "content": text})
-        response = self.client.chat.completions.create(
-            model=self.model,
-            messages=self.messages,
-            max_completion_tokens=1024,
-        )
-        reply = response.choices[0].message.content.strip()
-        self.messages.append({"role": "assistant", "content": reply})
-        # Keep context window bounded roughly.
-        if len(self.messages) > 20:
-            self.messages = [self.messages[0]] + self.messages[-18:]
-        return reply
+
+        for _ in range(8):
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=self.messages,
+                tools=self.tools,
+                tool_choice="auto",
+                max_completion_tokens=1024,
+            )
+            message = response.choices[0].message
+            self.messages.append(message)
+
+            if not message.tool_calls:
+                reply = message.content or ""
+                return reply.strip()
+
+            for call in message.tool_calls:
+                result = self._execute_tool(call)
+                self.messages.append(result)
+
+        return "I ran too many tool calls. Please rephrase your request."

--- a/fullstack-kimi/kimi-voice/audio.py
+++ b/fullstack-kimi/kimi-voice/audio.py
@@ -1,0 +1,78 @@
+# fullstack-kimi voice bridge: audio recording and playback.
+
+import io
+import threading
+import wave
+from pathlib import Path
+
+import numpy as np
+
+BUFFER = []
+LOCK = threading.Lock()
+RECORDING = False
+RATE = 16000
+CHANNELS = 1
+
+
+def _callback(indata, frames, time_info, status):
+    with LOCK:
+        if RECORDING:
+            BUFFER.append(indata.copy())
+
+
+def start_recording():
+    global BUFFER, RECORDING
+    with LOCK:
+        BUFFER = []
+        RECORDING = True
+    try:
+        import sounddevice as sd
+        sd.InputStream(samplerate=RATE, channels=CHANNELS, dtype="int16", callback=_callback).start()
+    except Exception as exc:
+        print(f"[audio input error: {exc}]")
+
+
+def stop_recording():
+    global RECORDING
+    with LOCK:
+        RECORDING = False
+        frames = BUFFER[:]
+    if not frames:
+        return None
+    data = np.concatenate(frames, axis=0)
+    wav_path = Path("/tmp/kimi_voice_input.wav")
+    with wave.open(str(wav_path), "wb") as wf:
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(2)
+        wf.setframerate(RATE)
+        wf.writeframes(data.astype(np.int16).tobytes())
+    return wav_path
+
+
+def current_levels():
+    with LOCK:
+        if not BUFFER:
+            return [0.0] * 16
+        recent = BUFFER[-3:] if len(BUFFER) >= 3 else BUFFER
+    if not recent:
+        return [0.0] * 16
+    data = np.concatenate(recent, axis=0).astype(np.float32) / 32768.0
+    chunk = len(data) // 16
+    if chunk == 0:
+        return [0.0] * 16
+    levels = []
+    for i in range(16):
+        frame = data[i * chunk:(i + 1) * chunk]
+        levels.append(min(1.0, np.sqrt(np.mean(frame ** 2)) * 4))
+    return levels
+
+
+def play_wav(wav_path):
+    try:
+        import sounddevice as sd
+        import soundfile as sf
+        data, rate = sf.read(str(wav_path), dtype="float32")
+        sd.play(data, rate)
+        sd.wait()
+    except Exception as exc:
+        print(f"[audio playback error: {exc}]")

--- a/fullstack-kimi/kimi-voice/bridge.py
+++ b/fullstack-kimi/kimi-voice/bridge.py
@@ -33,7 +33,7 @@ from config import load_config
 class VoiceBridge:
     def __init__(self):
         self.cfg = load_config()
-        self.agent = Agent(self.cfg)
+        self.agent = Agent(self.cfg, approve_callback=self._approve_tool)
         self.stt = stt.STT(self.cfg)
         self.tts = tts.TTS(self.cfg)
         self.bus_dir = Path(self.cfg.get("bus_dir", "~")).expanduser()
@@ -43,6 +43,8 @@ class VoiceBridge:
         self.running = True
         self.talk_key = self.cfg.get("talk_key", "home")
         self.permission_mode = self.cfg.get("permission_mode", "ask")
+        self._approval_received = False
+        self._waiting_for_approval = False
 
         signal.signal(signal.SIGINT, self._on_signal)
         signal.signal(signal.SIGTERM, self._on_signal)
@@ -53,8 +55,37 @@ class VoiceBridge:
         self.state.set_idle()
         sys.exit(0)
 
+    def _approve_tool(self, name, description):
+        if self.permission_mode == "auto":
+            return True
+        # ask mode: speak the request and wait briefly for the talk key.
+        msg = f"May I run {name}?"
+        print(f"[asking permission] {msg}")
+        self.state.set_speaking(msg)
+        self.tts.speak(msg)
+        self.state.set_thinking()
+        # Simple timeout-based approval: wait up to 5 seconds for the talk key.
+        self._approval_received = False
+        self._waiting_for_approval = True
+        deadline = time.time() + 5
+        while time.time() < deadline and self.running:
+            if self._approval_received:
+                self._approval_received = False
+                self._waiting_for_approval = False
+                print(f"[approved] {name}")
+                return True
+            time.sleep(0.05)
+        self._waiting_for_approval = False
+        print(f"[denied by timeout] {name}")
+        return False
+
     def _on_press(self, key):
-        if self._key_matches(key, self.talk_key) and not self.listening:
+        if not self._key_matches(key, self.talk_key):
+            return
+        if self._waiting_for_approval:
+            self._approval_received = True
+            return
+        if not self.listening:
             self.listening = True
             audio.start_recording()
             self.state.set_listening()

--- a/fullstack-kimi/kimi-voice/bridge.py
+++ b/fullstack-kimi/kimi-voice/bridge.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# fullstack-kimi voice bridge: push-to-talk agent voice.
+# Copyright (C) 2026 Jared Rhodenizer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Main loop for the fullstack-kimi voice bridge.
+
+Hold the configured talk key to record speech, release to send it to the
+agent, then listen as the agent thinks out loud and the face animates.
+
+The bridge writes two state files for the visualizer:
+    .kimi_state     -> {"state": "idle|listening|thinking|speaking", "text": "..."}
+    .kimi_waveform  -> {"levels": [...]}
+"""
+
+import json
+import os
+import signal
+import sys
+import threading
+import time
+from pathlib import Path
+
+import audio
+import state
+import stt
+import tts
+from agent import Agent
+from config import load_config
+
+
+class VoiceBridge:
+    def __init__(self):
+        self.cfg = load_config()
+        self.agent = Agent(self.cfg)
+        self.stt = stt.STT(self.cfg)
+        self.tts = tts.TTS(self.cfg)
+        self.bus_dir = Path(self.cfg.get("bus_dir", "~")).expanduser()
+        self.bus_dir.mkdir(parents=True, exist_ok=True)
+        self.state = state.StateWriter(self.bus_dir)
+        self.listening = False
+        self.running = True
+        self.talk_key = self.cfg.get("talk_key", "home")
+        self.permission_mode = self.cfg.get("permission_mode", "ask")
+
+        signal.signal(signal.SIGINT, self._on_signal)
+        signal.signal(signal.SIGTERM, self._on_signal)
+
+    def _on_signal(self, signum, frame):
+        print("\nshutting down...")
+        self.running = False
+        self.state.set_idle()
+        sys.exit(0)
+
+    def _on_press(self, key):
+        if self._key_matches(key, self.talk_key) and not self.listening:
+            self.listening = True
+            audio.start_recording()
+            self.state.set_listening()
+            print("[listening]")
+
+    def _on_release(self, key):
+        if self._key_matches(key, self.talk_key) and self.listening:
+            self.listening = False
+            self.state.set_thinking()
+            print("[thinking]")
+
+            wav_path = audio.stop_recording()
+            if wav_path is None:
+                self.state.set_idle()
+                return
+
+            try:
+                text = self.stt.transcribe(wav_path)
+            except Exception as exc:
+                print(f"[stt error: {exc}]")
+                self.tts.speak("I didn't catch that.")
+                self.state.set_idle()
+                return
+
+            if not text or not text.strip():
+                self.state.set_idle()
+                return
+
+            print(f"you: {text}")
+
+            try:
+                reply = self.agent.respond(text)
+            except Exception as exc:
+                print(f"[agent error: {exc}]")
+                self.tts.speak("I'm having trouble thinking right now.")
+                self.state.set_idle()
+                return
+
+            print(f"{self.cfg.get('name', 'agent')}: {reply}")
+            self.state.set_speaking(reply)
+            self.tts.speak(reply)
+            self.state.set_idle()
+
+    def _key_matches(self, key, name):
+        # Handle both pynput Key objects and raw key names.
+        try:
+            from pynput.keyboard import Key
+            if name == "home":
+                return key == Key.home
+            if name == "space":
+                return key == Key.space
+            if name == "shift":
+                return key == Key.shift
+            if name == "ctrl":
+                return key == Key.ctrl
+            if name == "alt":
+                return key == Key.alt
+            if hasattr(key, "char") and key.char:
+                return key.char.lower() == name.lower()
+        except Exception:
+            pass
+        return False
+
+    def _waveform_thread(self):
+        while self.running:
+            levels = audio.current_levels()
+            if self.listening or self.state.current_state == "speaking":
+                self.state.write_waveform(levels)
+            time.sleep(0.05)
+
+    def run(self):
+        print(f"fullstack-kimi voice bridge")
+        print(f"hold [{self.talk_key}] to talk, Ctrl-C to quit")
+
+        # Optional spoken greeting on launch.
+        greeting = self.cfg.get("greeting")
+        if greeting:
+            self.state.set_speaking(greeting)
+            self.tts.speak(greeting)
+            self.state.set_idle()
+
+        threading.Thread(target=self._waveform_thread, daemon=True).start()
+
+        try:
+            from pynput.keyboard import Listener
+            with Listener(on_press=self._on_press, on_release=self._on_release) as listener:
+                while self.running:
+                    listener.join(timeout=0.1)
+        except Exception as exc:
+            print(f"[keyboard listener error: {exc}]")
+            print("falling back to terminal input mode. Type your message and press Enter.")
+            while self.running:
+                try:
+                    text = input("> ")
+                    if text.strip():
+                        self.state.set_thinking()
+                        reply = self.agent.respond(text)
+                        print(f"{self.cfg.get('name', 'agent')}: {reply}")
+                        self.state.set_speaking(reply)
+                        self.tts.speak(reply)
+                        self.state.set_idle()
+                except EOFError:
+                    break
+
+
+def main():
+    bridge = VoiceBridge()
+    bridge.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/fullstack-kimi/kimi-voice/config.py
+++ b/fullstack-kimi/kimi-voice/config.py
@@ -1,0 +1,30 @@
+# fullstack-kimi voice bridge: configuration loader.
+
+import json
+import os
+from pathlib import Path
+
+DEFAULT_CONFIG = Path(__file__).parent / "kimi-voice.json"
+
+
+def load_config():
+    path = Path(os.environ.get("KIMI_VOICE_CONFIG", DEFAULT_CONFIG)).expanduser()
+    cfg = json.loads(path.read_text(encoding="utf-8"))
+
+    # Resolve paths.
+    for key in ("agent_dir", "bus_dir"):
+        if key in cfg:
+            cfg[key] = str(Path(cfg[key]).expanduser())
+    if "extra_dirs" in cfg:
+        cfg["extra_dirs"] = [str(Path(d).expanduser()) for d in cfg["extra_dirs"]]
+
+    # Inherit API keys from environment if not set in config.
+    llm = cfg.setdefault("llm", {})
+    if not llm.get("api_key"):
+        llm["api_key"] = os.environ.get("MOONSHOT_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+    stt = cfg.setdefault("stt", {})
+    if not stt.get("api_key"):
+        stt["api_key"] = os.environ.get("OPENAI_API_KEY") or os.environ.get("MOONSHOT_API_KEY")
+
+    return cfg

--- a/fullstack-kimi/kimi-voice/kimi-voice.json
+++ b/fullstack-kimi/kimi-voice/kimi-voice.json
@@ -1,0 +1,26 @@
+{
+  "name": "Kimi",
+  "greeting": "Hello there, what are we working on today?",
+  "agent_dir": "~/my-kimi-agent",
+  "bus_dir": "~/my-kimi-agent/kimi-voice",
+  "extra_dirs": ["~/my-kimi-agent/vault"],
+  "mic_mode": "ptt",
+  "talk_key": "home",
+  "permission_mode": "ask",
+  "stt": {
+    "engine": "whisper_api",
+    "api_key": null,
+    "model": "whisper-1"
+  },
+  "tts": {
+    "engine": "pyttsx3",
+    "voice": null,
+    "rate": 180
+  },
+  "llm": {
+    "backend": "kimi_api",
+    "api_key": null,
+    "base_url": "https://api.moonshot.ai/v1",
+    "model": "kimi-k3"
+  }
+}

--- a/fullstack-kimi/kimi-voice/requirements.txt
+++ b/fullstack-kimi/kimi-voice/requirements.txt
@@ -1,0 +1,6 @@
+openai>=1.30.0
+numpy
+sounddevice
+soundfile
+pynput
+pyttsx3

--- a/fullstack-kimi/kimi-voice/run.sh
+++ b/fullstack-kimi/kimi-voice/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# fullstack-kimi voice bridge launcher.
+# Copyright (C) 2026 Jared Rhodenizer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE" || exit 1
+
+# Prefer a local virtual environment if it exists.
+if [ -d "$HERE/.venv" ]; then
+  source "$HERE/.venv/bin/activate"
+fi
+
+exec python3 bridge.py

--- a/fullstack-kimi/kimi-voice/state.py
+++ b/fullstack-kimi/kimi-voice/state.py
@@ -1,0 +1,50 @@
+# fullstack-kimi voice bridge: state file writer for the visualizer.
+
+import json
+import threading
+from pathlib import Path
+
+
+class StateWriter:
+    def __init__(self, bus_dir: Path):
+        self.bus_dir = Path(bus_dir)
+        self.bus_dir.mkdir(parents=True, exist_ok=True)
+        self.current_state = "idle"
+        self.current_text = ""
+        self.lock = threading.Lock()
+
+    def _write(self):
+        state_file = self.bus_dir / ".kimi_state"
+        with self.lock:
+            state_file.write_text(
+                json.dumps({"state": self.current_state, "text": self.current_text}),
+                encoding="utf-8",
+            )
+
+    def set_idle(self):
+        with self.lock:
+            self.current_state = "idle"
+            self.current_text = ""
+        self._write()
+
+    def set_listening(self):
+        with self.lock:
+            self.current_state = "listening"
+            self.current_text = ""
+        self._write()
+
+    def set_thinking(self):
+        with self.lock:
+            self.current_state = "thinking"
+            self.current_text = ""
+        self._write()
+
+    def set_speaking(self, text: str):
+        with self.lock:
+            self.current_state = "speaking"
+            self.current_text = text
+        self._write()
+
+    def write_waveform(self, levels):
+        wf = self.bus_dir / ".kimi_waveform"
+        wf.write_text(json.dumps({"levels": levels}), encoding="utf-8")

--- a/fullstack-kimi/kimi-voice/stt.py
+++ b/fullstack-kimi/kimi-voice/stt.py
@@ -1,0 +1,32 @@
+# fullstack-kimi voice bridge: speech-to-text.
+
+from pathlib import Path
+
+
+class STT:
+    def __init__(self, cfg):
+        self.cfg = cfg.get("stt", {})
+        self.engine = self.cfg.get("engine", "whisper_api")
+
+    def transcribe(self, wav_path: Path) -> str:
+        if self.engine == "whisper_api":
+            return self._whisper_api(wav_path)
+        if self.engine == "faster_whisper":
+            return self._faster_whisper(wav_path)
+        raise ValueError(f"unknown stt engine: {self.engine}")
+
+    def _whisper_api(self, wav_path: Path) -> str:
+        from openai import OpenAI
+        api_key = self.cfg.get("api_key")
+        if not api_key:
+            raise RuntimeError("stt whisper_api requires an api_key or OPENAI_API_KEY env var")
+        client = OpenAI(api_key=api_key)
+        with open(wav_path, "rb") as f:
+            result = client.audio.transcriptions.create(model=self.cfg.get("model", "whisper-1"), file=f)
+        return result.text.strip()
+
+    def _faster_whisper(self, wav_path: Path) -> str:
+        from faster_whisper import WhisperModel
+        model = WhisperModel(self.cfg.get("model", "base"), device="cpu", compute_type="int8")
+        segments, _ = model.transcribe(str(wav_path))
+        return " ".join(s.text for s in segments).strip()

--- a/fullstack-kimi/kimi-voice/tools/system_tools.json
+++ b/fullstack-kimi/kimi-voice/tools/system_tools.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "bash",
+      "description": "Run a shell command in the agent's home directory. Use this for file operations, git, running scripts, and inspecting the system. Prefer read_file/write_file for file content; use bash for directory listings, git, and commands.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The shell command to run."
+          }
+        },
+        "required": ["command"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "read_file",
+      "description": "Read the contents of a file. Use this to inspect code, configs, or notes.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Absolute or home-relative path to the file."
+          }
+        },
+        "required": ["path"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "write_file",
+      "description": "Write content to a file. Creates parent directories if needed.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Absolute or home-relative path to the file."
+          },
+          "content": {
+            "type": "string",
+            "description": "Full content to write."
+          }
+        },
+        "required": ["path", "content"]
+      }
+    }
+  }
+]

--- a/fullstack-kimi/kimi-voice/tts.py
+++ b/fullstack-kimi/kimi-voice/tts.py
@@ -1,0 +1,51 @@
+# fullstack-kimi voice bridge: text-to-speech.
+
+import tempfile
+from pathlib import Path
+
+import audio
+
+
+class TTS:
+    def __init__(self, cfg):
+        self.cfg = cfg.get("tts", {})
+        self.engine = self.cfg.get("engine", "pyttsx3")
+
+    def speak(self, text: str):
+        if not text:
+            return
+        if self.engine == "pyttsx3":
+            self._pyttsx3(text)
+        elif self.engine == "edge_tts":
+            import asyncio
+            asyncio.run(self._edge_tts(text))
+        elif self.engine == "say":
+            import subprocess
+            subprocess.run(["say", text], check=False)
+        else:
+            raise ValueError(f"unknown tts engine: {self.engine}")
+
+    def _pyttsx3(self, text: str):
+        import pyttsx3
+        engine = pyttsx3.init()
+        rate = self.cfg.get("rate")
+        if rate:
+            engine.setProperty("rate", rate)
+        voice = self.cfg.get("voice")
+        if voice:
+            engine.setProperty("voice", voice)
+        engine.say(text)
+        engine.runAndWait()
+
+    async def _edge_tts(self, text: str):
+        import edge_tts
+        voice = self.cfg.get("voice", "en-US-AriaNeural")
+        communicate = edge_tts.Communicate(text, voice)
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
+            mp3_path = tmp.name
+        await communicate.save(mp3_path)
+        # Convert to wav for simple playback.
+        wav_path = Path(mp3_path).with_suffix(".wav")
+        import subprocess
+        subprocess.run(["ffmpeg", "-y", "-i", mp3_path, str(wav_path)], check=False, capture_output=True)
+        audio.play_wav(wav_path)

--- a/fullstack-kimi/start.sh
+++ b/fullstack-kimi/start.sh
@@ -42,21 +42,29 @@ trap cleanup EXIT INT TERM
 
 echo "fullstack-kimi: starting from $HOME_DIR"
 
-if [ -d "$HOME_DIR/kimi-visualizer" ] && [ "$MODE" != "hands" ]; then
-  (cd "$HOME_DIR/kimi-visualizer" && exec python3 server.py) &
+# Components can live either as siblings of this repo or bundled inside it.
+VIS_DIR="$HOME_DIR/kimi-visualizer"
+[ -d "$VIS_DIR" ] || VIS_DIR="$HERE/kimi-visualizer"
+HANDS_DIR="$HOME_DIR/kimi-barehands"
+[ -d "$HANDS_DIR" ] || HANDS_DIR="$HERE/kimi-barehands"
+VOICE_DIR="$HOME_DIR/kimi-voice"
+[ -d "$VOICE_DIR" ] || VOICE_DIR="$HERE/kimi-voice"
+
+if [ -d "$VIS_DIR" ] && [ "$MODE" != "hands" ]; then
+  (cd "$VIS_DIR" && exec python3 server.py) &
   PIDS+=($!)
   echo "  face:  starting (your browser opens on the visualizer)"
 fi
 
-if [ -d "$HOME_DIR/kimi-barehands" ] && [ "$MODE" != "voice" ]; then
-  (cd "$HOME_DIR/kimi-barehands" && exec python3 server.py) &
+if [ -d "$HANDS_DIR" ] && [ "$MODE" != "voice" ]; then
+  (cd "$HANDS_DIR" && exec python3 server.py) &
   PIDS+=($!)
   echo "  hands: starting (open the printed URL in Chrome when you want the board)"
 fi
 
-if [ -d "$HOME_DIR/kimi-voice" ]; then
+if [ -d "$VOICE_DIR" ]; then
   echo "  voice: starting (hold your talk key and speak; Ctrl-C here stops everything)"
-  cd "$HOME_DIR/kimi-voice" && ./run.sh
+  cd "$VOICE_DIR" && ./run.sh
 else
   echo
   echo "No voice installed; servers are up. Ctrl-C stops everything."

--- a/fullstack-kimi/start.sh
+++ b/fullstack-kimi/start.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# fullstack-kimi: give your AI a full stack — memory, voice, face, hands.
+# Copyright (C) 2026 Jared Rhodenizer
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Starts the agent's pieces, in the right order:
+#   kimi-visualizer (the face, opens in your browser)
+#   kimi-barehands  (the hands, URL printed; open it when you want the board)
+#   kimi-voice      (the voice, runs in this terminal; Ctrl-C stops EVERYTHING)
+# Pieces you didn't install are skipped automatically.
+#
+#   ./start.sh          everything installed
+#   ./start.sh voice    the voice and the face (no hands)
+#   ./start.sh hands    the voice and the hands board (no face)
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOME_DIR="$(dirname "$HERE")"
+MODE="${1:-all}"
+PIDS=()
+
+cleanup() {
+  trap - EXIT INT TERM
+  for p in "${PIDS[@]}"; do kill "$p" 2>/dev/null; done
+  echo
+  echo "agent stopped."
+}
+trap cleanup EXIT INT TERM
+
+echo "fullstack-kimi: starting from $HOME_DIR"
+
+if [ -d "$HOME_DIR/kimi-visualizer" ] && [ "$MODE" != "hands" ]; then
+  (cd "$HOME_DIR/kimi-visualizer" && exec python3 server.py) &
+  PIDS+=($!)
+  echo "  face:  starting (your browser opens on the visualizer)"
+fi
+
+if [ -d "$HOME_DIR/kimi-barehands" ] && [ "$MODE" != "voice" ]; then
+  (cd "$HOME_DIR/kimi-barehands" && exec python3 server.py) &
+  PIDS+=($!)
+  echo "  hands: starting (open the printed URL in Chrome when you want the board)"
+fi
+
+if [ -d "$HOME_DIR/kimi-voice" ]; then
+  echo "  voice: starting (hold your talk key and speak; Ctrl-C here stops everything)"
+  cd "$HOME_DIR/kimi-voice" && ./run.sh
+else
+  echo
+  echo "No voice installed; servers are up. Ctrl-C stops everything."
+  wait
+fi

--- a/fullstack-kimi/update.sh
+++ b/fullstack-kimi/update.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# fullstack-kimi: give your AI a full stack — memory, voice, face, hands.
+# Copyright (C) 2026 Jared Rhodenizer
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Pulls the newest version of every installed piece, and of this repo.
+# Your own files (your AGENTS.md/KIMI.md, your vault, your configs) live outside
+# the repos' tracked files, so updates never touch them. If git reports a
+# conflict on a config you edited, your edit wins; keep your version.
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOME_DIR="$(dirname "$HERE")"
+
+main() {
+  for repo in fullstack-kimi kimi-memory-vault kimi-voice kimi-barehands kimi-visualizer; do
+    [ -d "$HOME_DIR/$repo/.git" ] || continue
+    echo "== $repo"
+    git -C "$HOME_DIR/$repo" fetch -q origin 2>/dev/null
+    git -C "$HOME_DIR/$repo" log --oneline "..@{u}" 2>/dev/null | sed "s/^/   new: /"
+
+    CFG=""
+    case "$repo" in
+      kimi-voice) CFG="kimi-voice.json" ;;
+      kimi-barehands) CFG="kimi-barehands.json" ;;
+      kimi-visualizer) CFG="kimi-visualizer.json" ;;
+    esac
+    MIGRATE=0
+    if [ -n "$CFG" ] && [ -f "$HOME_DIR/$repo/$CFG" ] && \
+       git -C "$HOME_DIR/$repo" ls-files --error-unmatch "$CFG" >/dev/null 2>&1; then
+      cp "$HOME_DIR/$repo/$CFG" "$HOME_DIR/$repo/$CFG.mine" && \
+        git -C "$HOME_DIR/$repo" checkout -q -- "$CFG" && MIGRATE=1
+    fi
+    git -C "$HOME_DIR/$repo" pull --ff-only || \
+      echo "   (couldn't fast-forward; your local edits win.)"
+    if [ "$MIGRATE" = 1 ] && [ -f "$HOME_DIR/$repo/$CFG.mine" ]; then
+      mv "$HOME_DIR/$repo/$CFG.mine" "$HOME_DIR/$repo/$CFG"
+    fi
+  done
+  echo "update complete."
+}
+main "$@"


### PR DESCRIPTION
This PR adds a new `fullstack-kimi/` directory containing a Kimi-powered port of the fullstack-agent installer.

What is included:
- `KIMI.md` — boot instructions for the installer agent
- `fullstack-kimi.md` — the full setup wizard (phases 0–6)
- `README.md` — overview and install command
- `start.sh` / `update.sh` — launcher and updater scripts
- `TROUBLESHOOTING.md` — cross-piece troubleshooting
- `.gitignore` — ignore user state and logs

Design notes:
- Uses **Kimi Code CLI** as the host brain (analogous to Claude Code in fullstack-agent).
- Identity lives in `AGENTS.md` / optional `SYSTEM.md` instead of `CLAUDE.md`.
- Voice/face/hands connect via state files and the Kimi Code CLI Wire bridge.
- Component repos (`kimi-memory-vault`, `kimi-voice`, `kimi-visualizer`, `kimi-barehands`) are referenced but not yet implemented; this PR establishes the installer architecture first.