### PR TITLE
Fix grammar: remove incorrect comma before restrictive 'that' clause

### DIFF
--- a/fullstack-agent.md
+++ b/fullstack-agent.md
@@ -65,7 +65,7 @@ ai-memory-vault, backtalk, barehands, ai-visualizer.
 
 **The adoption exceptions, checked before each clone:**
 
-- A piece already downloaded from these repos somewhere on the machine, that they actively use: do not duplicate it. Wire to their copy where it stands; wiring is just paths. A stale, unmodified copy sitting outside the home folder is different: prefer a fresh copy inside the home (so the update script reaches it) and leave the old one untouched.
+- A piece already downloaded from these repos somewhere on the machine that they actively use: do not duplicate it. Wire to their copy where it stands; wiring is just paths. A stale, unmodified copy sitting outside the home folder is different: prefer a fresh copy inside the home (so the update script reaches it) and leave the old one untouched.
 - A HAND-BUILT voice line or visualizer from the prompts era: our repo installs as the new default, and you say the honest sentence: "your old build stays right where it is; it just will not be the one that runs." Their files are never touched.
 - A hand-built visualizer SCENE (they designed what appears on screen): offer the promotion. COPY, never move, their page into `ai-visualizer/faces/<their-name-for-it>/index.html` with a small `face.json`, so their creation appears in the gallery beside the shipped faces. This is the one piece of the old world that is not an inferior copy of ours; treat it with respect.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `fullstack-agent.md` (line 68).

## Problem

A comma incorrectly precedes the restrictive relative clause "that they actively use". In standard English grammar, restrictive clauses introduced by "that" should not be preceded by a comma.

The problematic text:

```markdown
A piece already downloaded from these repos somewhere on the machine, that they actively use:
```

## Fix

Removed the comma before "that":

```markdown
A piece already downloaded from these repos somewhere on the machine that they actively use:
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text