### PR TITLE
Fix grammar: correct 'neither...nor' verb agreement in fullstack-agent.md

### DIFF
--- a/fullstack-agent.md
+++ b/fullstack-agent.md
@@ -136,7 +136,7 @@ Then **make the launchers**, so they never have to remember any of this. Four sh
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 ```
 
-A double-clicked shortcut launches with a bare system PATH where neither `claude` nor `uv` exist, so a launcher without the export fails silently. (Windows `.bat` files inherit the user's PATH and do not need it.)
+A double-clicked shortcut launches with a bare system PATH where neither `claude` nor `uv` exists, so a launcher without the export fails silently. (Windows `.bat` files inherit the user's PATH and do not need it.)
 
 On macOS make each `.command` executable, and warn them once: the first double-click may ask permission; that is macOS being protective, click Open.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `fullstack-agent.md` (line 139).

## Problem

Subject-verb agreement error with "neither...nor" construction. When both subjects are singular, the verb should agree with the nearer subject ("uv" → singular → "exists").

The problematic text:

```markdown
where neither `claude` nor `uv` exist
```

## Fix

```markdown
where neither `claude` nor `uv` exists
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text