### PR TITLE
Fix grammar: add missing head noun 'distributions' after 'most Linux'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then you're exactly who this was designed around. If you set up a memory vault, 
 
 - The wizard never deletes, overwrites, or moves anything you built. Replacements retire the old thing in place and say so.
 - Your vault stays wherever it already lives. Pieces connect by configuration paths, not by relocation.
-- Requirements per piece: the voice needs a mic and about 1 GB of local models on first run; the hands need a webcam and Chrome; the mind and face need nothing but Python 3, which ships with macOS and most Linux. Windows notes live in each piece's own README.
+- Requirements per piece: the voice needs a mic and about 1 GB of local models on first run; the hands need a webcam and Chrome; the mind and face need nothing but Python 3, which ships with macOS and most Linux distributions. Windows notes live in each piece's own README.
 - Cross-piece problems: `TROUBLESHOOTING.md` here. Everything else: each piece's own guide.
 
 ## The rest of it


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 67).

## Problem

"most Linux" uses the proper noun "Linux" as a pluralizable noun without a head noun. Linux is an OS family/kernel, not a countable entity. It should be "most Linux distributions".

The problematic text:

```markdown
which ships with macOS and most Linux.
```

## Fix

```markdown
which ships with macOS and most Linux distributions.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text